### PR TITLE
Added support for `append_environment` configuration

### DIFF
--- a/lib/apartment.rb
+++ b/lib/apartment.rb
@@ -3,7 +3,7 @@ require 'apartment/railtie' if defined?(Rails)
 module Apartment
 
   class << self
-    ACCESSOR_METHODS  = [:use_postgres_schemas, :seed_after_create, :prepend_environment]
+    ACCESSOR_METHODS  = [:use_postgres_schemas, :seed_after_create, :prepend_environment, :append_environment]
     WRITER_METHODS    = [:database_names, :excluded_models, :default_schema, :persistent_schemas, :connection_class]
 
     attr_accessor(*ACCESSOR_METHODS)

--- a/lib/apartment/adapters/abstract_adapter.rb
+++ b/lib/apartment/adapters/abstract_adapter.rb
@@ -137,7 +137,17 @@ module Apartment
       #   @return {String} database name with Rails environment *optionally* prepended
       #
       def environmentify(database)
-        Apartment.prepend_environment && !database.include?(Rails.env) ? "#{Rails.env}_#{database}" : database
+        unless database.include?(Rails.env)
+          if Apartment.prepend_environment
+            "#{Rails.env}_#{database}"
+          elsif Apartment.append_environment
+            "#{database}_#{Rails.env}"
+          else
+            database
+          end
+        else
+          database
+        end
       end
 
       #   Import the database schema

--- a/lib/apartment/railtie.rb
+++ b/lib/apartment/railtie.rb
@@ -14,6 +14,7 @@ module Apartment
         config.database_names = []
         config.seed_after_create = false
         config.prepend_environment = false
+        config.append_environment = false
       end
     end
 

--- a/spec/examples/generic_adapter_examples.rb
+++ b/spec/examples/generic_adapter_examples.rb
@@ -3,7 +3,10 @@ require 'spec_helper'
 shared_examples_for "a generic apartment adapter" do
   include Apartment::Spec::AdapterRequirements
 
-  before{ Apartment.prepend_environment = false }
+  before {
+    Apartment.prepend_environment = false
+    Apartment.append_environment = false
+  }
 
   #
   #   Creates happen already in our before_filter


### PR DESCRIPTION
Added `append_environment` configuration setting which determines whether the Rails environment name is added on to the tenant database name.

Note: The `prepend_environment` configuration setting is mutually exclusive to  `append_environment`  and takes precedence over `append_environment`. 
