### PR TITLE
Support for postgis adapter

### DIFF
--- a/lib/apartment/adapters/postgis_adapter.rb
+++ b/lib/apartment/adapters/postgis_adapter.rb
@@ -1,0 +1,15 @@
+# handle postgis adapter as if it were postgresql,
+# only override the adapter_method used for initialization
+require "apartment/adapters/postgresql_adapter"
+
+module Apartment
+
+  module Database
+
+    def self.postgis_adapter(config)
+      Apartment.use_postgres_schemas ?
+        Adapters::PostgresqlSchemaAdapter.new(config) :
+        Adapters::PostgresqlAdapter.new(config)
+    end
+  end
+end


### PR DESCRIPTION
This adds support for [activerecord-postgis-adapter](https://github.com/dazuma/activerecord-postgis-adapter). Postgis-adapter is very similar to postgresql adapter from all the parts that are relevant for apartment to work, so this is essentially only an alias to make the loading work.

I didn't bother writing any tests yet (have a working app using this, though), but if you consider merging this in, I can take a look at that too.
