### PR TITLE
Improvements to rake tasks

### DIFF
--- a/lib/tasks/apartment.rake
+++ b/lib/tasks/apartment.rake
@@ -26,7 +26,7 @@ apartment_namespace = namespace :apartment do
   end
 
   desc "Seed all multi-tenant databases"
-  task :seed => :environment do
+  task :seed => 'db:seed' do
 
     database_names.each do |db|
       begin


### PR DESCRIPTION
This PR adds the possibility to specify a comma separated list of DB on which you want to execute the task with the DB environment variable.

It also adds a task to create databases

```
DB=mydatabase rake apartment:create
```

If DB variable is not specified, it will try to create every database from Apartment.database_names.
