### PR TITLE
Fix Rails 4 incompatibilty

### DIFF
--- a/lib/apartment/adapters/postgresql_adapter.rb
+++ b/lib/apartment/adapters/postgresql_adapter.rb
@@ -73,7 +73,7 @@ module Apartment
       #
       def connect_to_new(database = nil)
         return reset if database.nil?
-        raise ActiveRecord::StatementInvalid.new unless Apartment.connection.schema_exists? database
+        raise ActiveRecord::StatementInvalid.new("Could not find schema #{database}") unless Apartment.connection.schema_exists? database
 
         @current_database = database.to_s
         Apartment.connection.schema_search_path = full_search_path


### PR DESCRIPTION
When I am using Apartment with Rails 4, it errors because `ActiveRecord::StatementInvalid.new` now takes _at least_ one argument. This patch is fairly simple and works with Rails 3 and Rails 4.
