### PR TITLE
Run migrations in parallel

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,17 @@ You can then migrate your databases using the rake task:
 This basically invokes `Apartment::Database.migrate(#{db_name})` for each database name supplied
 from `Apartment.database_names`
 
+#### Parallel Migrations
+
+Apartment supports parallelizing migrations into multiple threads when
+you have a large number of tenants. By default, parallel migrations is
+turned off. You can enable this by setting `parallel_migration_threads` to 
+the number of threads you want to use in your initializer.
+
+Keep in mind that because migrations are going to access the database,
+the number of threads indicated here should be less than the pool size
+that Rails will use to connect to your database.
+
 ### Handling Environments
 
 By default, when not using postgresql schemas, Apartment will prepend the environment to the database name

--- a/apartment.gemspec
+++ b/apartment.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'activerecord',    '>= 3.1.2'   # must be >= 3.1.2 due to bug in prepared_statements
   s.add_dependency 'rack',            '>= 1.3.6'
+  s.add_dependency 'parallel',        '>= 0.7.1'
 
   s.add_development_dependency 'appraisal'
   s.add_development_dependency 'rake',         '~> 0.9'

--- a/lib/apartment.rb
+++ b/lib/apartment.rb
@@ -11,7 +11,7 @@ module Apartment
     extend Forwardable
 
     ACCESSOR_METHODS  = [:use_schemas, :seed_after_create, :prepend_environment, :append_environment]
-    WRITER_METHODS    = [:database_names, :database_schema_file, :excluded_models, :default_schema, :persistent_schemas, :connection_class]
+    WRITER_METHODS    = [:database_names, :database_schema_file, :excluded_models, :default_schema, :persistent_schemas, :connection_class, :parallel_migration_threads]
 
     attr_accessor(*ACCESSOR_METHODS)
     attr_writer(*WRITER_METHODS)
@@ -35,6 +35,10 @@ module Apartment
 
     def default_schema
       @default_schema || "public"
+    end
+
+    def parallel_migration_threads
+      @parallel_migration_threads || 0
     end
 
     def persistent_schemas


### PR DESCRIPTION
I added the ability to run migrations in parallel. This is useful when you have a large number of schemas.

By default, migrations will be run sequentially as they currently are, but a new configuration option allows parallelization within a specified number of threads.
