### PR TITLE
run migrations from all registered migrations paths

### DIFF
--- a/lib/apartment/migrator.rb
+++ b/lib/apartment/migrator.rb
@@ -10,7 +10,7 @@ module Apartment
       Database.process(database) do
         version = ENV["VERSION"] ? ENV["VERSION"].to_i : nil
 
-        ActiveRecord::Migrator.migrate(ActiveRecord::Migrator.migrations_path, version) do |migration|
+        ActiveRecord::Migrator.migrate(ActiveRecord::Migrator.migrations_paths, version) do |migration|
           ENV["SCOPE"].blank? || (ENV["SCOPE"] == migration.scope)
         end
       end
@@ -19,14 +19,14 @@ module Apartment
     # Migrate up/down to a specific version
     def run(direction, database, version)
       Database.process(database) do
-        ActiveRecord::Migrator.run(direction, ActiveRecord::Migrator.migrations_path, version)
+        ActiveRecord::Migrator.run(direction, ActiveRecord::Migrator.migrations_paths, version)
       end
     end
 
     # rollback latest migration `step` number of times
     def rollback(database, step = 1)
       Database.process(database) do
-        ActiveRecord::Migrator.rollback(ActiveRecord::Migrator.migrations_path, step)
+        ActiveRecord::Migrator.rollback(ActiveRecord::Migrator.migrations_paths, step)
       end
     end
   end


### PR DESCRIPTION
ActiveRecord::Migrator.migrate is supposed and able to receive an array of migration paths in order to support multiple directories containing migrations (e.g. inside engines...)

see https://github.com/rails/rails/blob/master/activerecord/lib/active_record/migration.rb#L782
and https://github.com/rails/rails/commit/d0467e08e54a84fc4672c508716615aa0177994a

since `rake db:migrate` finds and executes all containing migrations on the public schema (for pg), `rake apartment:migrate` should do the same on the tenants' schemas.
