### PR TITLE
Deprecate Apartment::Database in favor of Apartment::Tenant

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Before you can switch to a new apartment tenant, you will need to create it. Whe
 you need to create a new tenant, you can run the following command:
 
 ```ruby
-Apartment::Database.create('tenant_name')
+Apartment::Tenant.create('tenant_name')
 ```
 
 If you're using the [prepend environment](https://github.com/influitive/apartment#handling-environments) config option or you AREN'T using Postgresql Schemas, this will create a tenant in the following format: "#{environment}\_tenant_name".
@@ -67,7 +67,7 @@ One can optionally use the full database creation instead if they want, though t
 To switch tenants using Apartment, use the following command:
 
 ```ruby
-Apartment::Database.switch('tenant_name')
+Apartment::Tenant.switch('tenant_name')
 ```
 
 When switch is called, all requests coming to ActiveRecord will be routed to the tenant
@@ -186,7 +186,7 @@ By default, ActiveRecord will use `"$user", public` as the default `schema_searc
 config.default_schema = "some_other_schema"
 ```
 
-With that set, all excluded models will use this schema as the table name prefix instead of `public` and `reset` on `Apartment::Database` will return to this schema also
+With that set, all excluded models will use this schema as the table name prefix instead of `public` and `reset` on `Apartment::Tenant` will return to this schema also
 
 **Persistent Schemas**
 Apartment will normally just switch the `schema_search_path` whole hog to the one passed in.  This can lead to problems if you want other schemas to always be searched as well.  Enter `persistent_schemas`.  You can configure a list of other schemas that will always remain in the search path, while the default gets swapped out:
@@ -270,7 +270,7 @@ You can then migrate your tenants using the normal rake task:
 rake db:migrate
 ```
 
-This just invokes `Apartment::Database.migrate(#{tenant_name})` for each tenant name supplied
+This just invokes `Apartment::Tenant.migrate(#{tenant_name})` for each tenant name supplied
 from `Apartment.tenant_names`
 
 Note that you can disable the default migrating of all tenants with `db:migrate` by setting

--- a/TODO.md
+++ b/TODO.md
@@ -19,9 +19,9 @@
 
     This should ensure that going forward nothing breaks, and we should *ideally* be able to randomize the test order
 
-2.  `Apartment::Database` is the wrong abstraction. When dealing with a multi-tenanted system, users shouldn't thing about 'Databases', they should
+2.  <del>`Apartment::Database` is the wrong abstraction. When dealing with a multi-tenanted system, users shouldn't thing about 'Databases', they should
     think about Tenants. I proprose that we deprecate the `Apartment::Database` constant in favour of `Apartment::Tenant` for a nicer abstraction. See
-    http://myronmars.to/n/dev-blog/2011/09/deprecating-constants-and-classes-in-ruby for ideas on how to achieve this.
+    http://myronmars.to/n/dev-blog/2011/09/deprecating-constants-and-classes-in-ruby for ideas on how to achieve this.</del>
 
 4.  Apartment::Database.process should be deprecated in favour of just passing a block to `switch`
 5.  Apartment::Database.switch should be renamed to switch! to indicate that using it on its own has side effects

--- a/lib/apartment.rb
+++ b/lib/apartment.rb
@@ -2,7 +2,7 @@ require 'apartment/railtie' if defined?(Rails)
 require 'active_support/core_ext/object/blank'
 require 'forwardable'
 require 'active_record'
-require 'apartment/database'
+require 'apartment/tenant'
 
 module Apartment
 

--- a/lib/apartment/adapters/jdbc_mysql_adapter.rb
+++ b/lib/apartment/adapters/jdbc_mysql_adapter.rb
@@ -2,7 +2,7 @@ require "apartment/adapters/abstract_jdbc_adapter"
 
 module Apartment
 
-  module Database
+  module Tenant
     def self.jdbc_mysql_adapter(config)
       Adapters::JDBCMysqlAdapter.new config
     end
@@ -22,7 +22,7 @@ module Apartment
       def connect_to_new(database)
         super
       rescue DatabaseNotFound
-        Apartment::Database.reset
+        Apartment::Tenant.reset
         raise DatabaseNotFound, "Cannot find database #{environmentify(database)}"
       end
     end

--- a/lib/apartment/adapters/jdbc_postgresql_adapter.rb
+++ b/lib/apartment/adapters/jdbc_postgresql_adapter.rb
@@ -1,7 +1,7 @@
 require 'apartment/adapters/postgresql_adapter'
 
 module Apartment
-  module Database
+  module Tenant
 
     def self.jdbc_postgresql_adapter(config)
       Apartment.use_schemas ?

--- a/lib/apartment/adapters/mysql2_adapter.rb
+++ b/lib/apartment/adapters/mysql2_adapter.rb
@@ -1,7 +1,7 @@
 require 'apartment/adapters/abstract_adapter'
 
 module Apartment
-  module Database
+  module Tenant
 
     def self.mysql2_adapter(config)
       Apartment.use_schemas ?
@@ -24,7 +24,7 @@ module Apartment
       def connect_to_new(tenant = nil)
         super
       rescue Mysql2::Error
-        Apartment::Database.reset
+        Apartment::Tenant.reset
         raise DatabaseNotFound, "Cannot find tenant #{environmentify(tenant)}"
       end
     end
@@ -61,7 +61,7 @@ module Apartment
         Apartment.connection.execute "use #{environmentify(tenant)}"
 
       rescue ActiveRecord::StatementInvalid
-        Apartment::Database.reset
+        Apartment::Tenant.reset
         raise DatabaseNotFound, "Cannot find tenant #{environmentify(tenant)}"
       end
 

--- a/lib/apartment/adapters/postgis_adapter.rb
+++ b/lib/apartment/adapters/postgis_adapter.rb
@@ -3,7 +3,7 @@
 require "apartment/adapters/postgresql_adapter"
 
 module Apartment
-  module Database
+  module Tenant
 
     def self.postgis_adapter(config)
       Apartment.use_schemas ?

--- a/lib/apartment/adapters/postgresql_adapter.rb
+++ b/lib/apartment/adapters/postgresql_adapter.rb
@@ -1,7 +1,7 @@
 require 'apartment/adapters/abstract_adapter'
 
 module Apartment
-  module Database
+  module Tenant
 
     def self.postgresql_adapter(config)
       adapter = Adapters::PostgresqlAdapter

--- a/lib/apartment/adapters/sqlite3_adapter.rb
+++ b/lib/apartment/adapters/sqlite3_adapter.rb
@@ -1,7 +1,7 @@
 require 'apartment/adapters/abstract_adapter'
 
 module Apartment
-  module Database
+  module Tenant
     def self.sqlite3_adapter(config)
       Adapters::Sqlite3Adapter.new(config)
     end

--- a/lib/apartment/console.rb
+++ b/lib/apartment/console.rb
@@ -1,4 +1,4 @@
-# A workaraound to get `reload!` to also call Apartment::Database.init
+# A workaraound to get `reload!` to also call Apartment::Tenant.init
 # This is unfortunate, but I haven't figured out how to hook into the reload process *after* files are reloaded
 
 # reloads the environment
@@ -7,6 +7,6 @@ def reload!(print=true)
   # This triggers the to_prepare callbacks
   ActionDispatch::Callbacks.new(Proc.new {}).call({})
   # Manually init Apartment again once classes are reloaded
-  Apartment::Database.init
+  Apartment::Tenant.init
   true
 end

--- a/lib/apartment/elevators/generic.rb
+++ b/lib/apartment/elevators/generic.rb
@@ -1,5 +1,5 @@
 require 'rack/request'
-require 'apartment/database'
+require 'apartment/tenant'
 
 module Apartment
   module Elevators
@@ -17,7 +17,7 @@ module Apartment
 
         database = @processor.call(request)
 
-        Apartment::Database.switch database if database
+        Apartment::Tenant.switch database if database
 
         @app.call(env)
       end

--- a/lib/apartment/migrator.rb
+++ b/lib/apartment/migrator.rb
@@ -1,4 +1,4 @@
-require 'apartment/database'
+require 'apartment/tenant'
 
 module Apartment
   module Migrator

--- a/lib/apartment/railtie.rb
+++ b/lib/apartment/railtie.rb
@@ -1,5 +1,5 @@
 require 'rails'
-require 'apartment/database'
+require 'apartment/tenant'
 require 'apartment/reloader'
 
 module Apartment
@@ -28,7 +28,7 @@ module Apartment
     #   See the middleware/console declarations below to help with this. Hope to fix that soon.
     #
     config.to_prepare do
-      Apartment::Database.init
+      Apartment::Tenant.init
     end
 
     #
@@ -50,7 +50,7 @@ module Apartment
         app.config.middleware.use "Apartment::Reloader"
       end
 
-      # Overrides reload! to also call Apartment::Database.init as well so that the reloaded classes have the proper table_names
+      # Overrides reload! to also call Apartment::Tenant.init as well so that the reloaded classes have the proper table_names
       console do
         require 'apartment/console'
       end

--- a/lib/apartment/tenant.rb
+++ b/lib/apartment/tenant.rb
@@ -3,7 +3,7 @@ require 'forwardable'
 module Apartment
   #   The main entry point to Apartment functions
   #
-  module Database
+  module Tenant
 
     extend self
     extend Forwardable
@@ -63,5 +63,11 @@ module Apartment
       @config ||= (ActiveRecord::Base.configurations[Rails.env] ||
                     Rails.application.config.database_configuration[Rails.env]).symbolize_keys
     end
+  end
+
+  def self.const_missing(const_name)
+    super unless const_name == :Database
+    warn "`Apartment::Database` has been deprecated. Use `Apartment::Tenant` instead."
+    Tenant
   end
 end

--- a/lib/tasks/apartment.rake
+++ b/lib/tasks/apartment.rake
@@ -7,7 +7,7 @@ apartment_namespace = namespace :apartment do
     tenants.each do |tenant|
       begin
         puts("Creating #{tenant} tenant")
-        quietly { Apartment::Database.create(tenant) }
+        quietly { Apartment::Tenant.create(tenant) }
       rescue Apartment::TenantExists => e
         puts e.message
       end
@@ -35,8 +35,8 @@ apartment_namespace = namespace :apartment do
     tenants.each do |tenant|
       begin
         puts("Seeding #{tenant} tenant")
-        Apartment::Database.process(tenant) do
-          Apartment::Database.seed
+        Apartment::Tenant.process(tenant) do
+          Apartment::Tenant.seed
         end
       rescue Apartment::TenantNotFound => e
         puts e.message

--- a/spec/adapters/jdbc_mysql_adapter_spec.rb
+++ b/spec/adapters/jdbc_mysql_adapter_spec.rb
@@ -5,7 +5,7 @@ if defined?(JRUBY_VERSION)
 
   describe Apartment::Adapters::JDBCMysqlAdapter, database: :mysql do
 
-    subject { Apartment::Database.jdbc_mysql_adapter config.symbolize_keys }
+    subject { Apartment::Tenant.jdbc_mysql_adapter config.symbolize_keys }
 
     def tenant_names
       ActiveRecord::Base.connection.execute("SELECT schema_name FROM information_schema.schemata").collect { |row| row['schema_name'] }

--- a/spec/adapters/jdbc_postgresql_adapter_spec.rb
+++ b/spec/adapters/jdbc_postgresql_adapter_spec.rb
@@ -5,7 +5,7 @@ if defined?(JRUBY_VERSION)
 
   describe Apartment::Adapters::JDBCPostgresqlAdapter, database: :postgresql do
 
-    subject { Apartment::Database.jdbc_postgresql_adapter config.symbolize_keys }
+    subject { Apartment::Tenant.jdbc_postgresql_adapter config.symbolize_keys }
 
     context "using schemas" do
 

--- a/spec/adapters/mysql2_adapter_spec.rb
+++ b/spec/adapters/mysql2_adapter_spec.rb
@@ -4,7 +4,7 @@ require 'apartment/adapters/mysql2_adapter'
 describe Apartment::Adapters::Mysql2Adapter, database: :mysql do
   unless defined?(JRUBY_VERSION)
 
-    subject(:adapter){ Apartment::Database.mysql2_adapter config }
+    subject(:adapter){ Apartment::Tenant.mysql2_adapter config }
 
     def tenant_names
       ActiveRecord::Base.connection.execute("SELECT schema_name FROM information_schema.schemata").collect { |row| row[0] }
@@ -31,7 +31,7 @@ describe Apartment::Adapters::Mysql2Adapter, database: :mysql do
         end
 
         it "should process model exclusions" do
-          Apartment::Database.init
+          Apartment::Tenant.init
 
           Company.table_name.should == "#{default_tenant}.companies"
         end

--- a/spec/adapters/postgresql_adapter_spec.rb
+++ b/spec/adapters/postgresql_adapter_spec.rb
@@ -4,7 +4,7 @@ require 'apartment/adapters/postgresql_adapter'
 describe Apartment::Adapters::PostgresqlAdapter, database: :postgresql do
   unless defined?(JRUBY_VERSION)
 
-    subject{ Apartment::Database.postgresql_adapter config }
+    subject{ Apartment::Tenant.postgresql_adapter config }
 
     context "using schemas with schema.rb" do
 

--- a/spec/adapters/sqlite3_adapter_spec.rb
+++ b/spec/adapters/sqlite3_adapter_spec.rb
@@ -4,7 +4,7 @@ require 'apartment/adapters/sqlite3_adapter'
 describe Apartment::Adapters::Sqlite3Adapter, database: :sqlite do
   unless defined?(JRUBY_VERSION)
 
-    subject{ Apartment::Database.sqlite3_adapter config }
+    subject{ Apartment::Tenant.sqlite3_adapter config }
 
     context "using connections" do
       def tenant_names

--- a/spec/apartment_spec.rb
+++ b/spec/apartment_spec.rb
@@ -8,4 +8,8 @@ describe Apartment do
   it "should be a valid app" do
     ::Rails.application.should be_a(Dummy::Application)
   end
+
+  it "should deprecate Apartment::Database in favor of Apartment::Tenant" do
+    expect(Apartment::Database).to eq(Apartment::Tenant)
+  end
 end

--- a/spec/database_spec.rb
+++ b/spec/database_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Apartment::Database do
+describe Apartment::Tenant do
   context "using mysql", database: :mysql do
 
     before do
@@ -77,7 +77,7 @@ describe Apartment::Database do
         subject.stub(:config).and_return config.merge(:adapter => 'unknown')
 
         expect {
-          Apartment::Database.adapter
+          Apartment::Tenant.adapter
         }.to raise_error
       end
 

--- a/spec/examples/connection_adapter_examples.rb
+++ b/spec/examples/connection_adapter_examples.rb
@@ -10,7 +10,7 @@ shared_examples_for "a connection based apartment adapter" do
       Apartment.configure do |config|
         config.excluded_models = ["Company"]
       end
-      Apartment::Database.init
+      Apartment::Tenant.init
 
       Company.connection.object_id.should_not == ActiveRecord::Base.connection.object_id
     end

--- a/spec/examples/schema_adapter_examples.rb
+++ b/spec/examples/schema_adapter_examples.rb
@@ -16,7 +16,7 @@ shared_examples_for "a schema based apartment adapter" do
     end
 
     it "should process model exclusions" do
-      Apartment::Database.init
+      Apartment::Tenant.init
 
       Company.table_name.should == "public.companies"
     end
@@ -24,13 +24,13 @@ shared_examples_for "a schema based apartment adapter" do
     context "with a default_schema", :default_schema => true do
 
       it "should set the proper table_name on excluded_models" do
-        Apartment::Database.init
+        Apartment::Tenant.init
 
         Company.table_name.should == "#{default_schema}.companies"
       end
 
       it 'sets the search_path correctly' do
-        Apartment::Database.init
+        Apartment::Tenant.init
 
         User.connection.schema_search_path.should =~ %r|#{default_schema}|
       end
@@ -38,7 +38,7 @@ shared_examples_for "a schema based apartment adapter" do
 
     context "persistent_schemas", :persistent_schemas => true do
       it "sets the persistent schemas in the schema_search_path" do
-        Apartment::Database.init
+        Apartment::Tenant.init
         connection.schema_search_path.should end_with persistent_schemas.map { |schema| %{"#{schema}"} }.join(', ')
       end
     end

--- a/spec/integration/apartment_rake_integration_spec.rb
+++ b/spec/integration/apartment_rake_integration_spec.rb
@@ -21,7 +21,7 @@ describe "apartment rake tasks", database: :postgresql do
       config.excluded_models = ["Company"]
       config.tenant_names = lambda{ Company.pluck(:database) }
     end
-    Apartment::Database.reload!(config)
+    Apartment::Tenant.reload!(config)
 
     # fix up table name of shared/excluded models
     Company.table_name = 'public.companies'
@@ -37,13 +37,13 @@ describe "apartment rake tasks", database: :postgresql do
 
     before do
       db_names.collect do |db_name|
-        Apartment::Database.create(db_name)
+        Apartment::Tenant.create(db_name)
         Company.create :database => db_name
       end
     end
 
     after do
-      db_names.each{ |db| Apartment::Database.drop(db) }
+      db_names.each{ |db| Apartment::Tenant.drop(db) }
       Company.delete_all
     end
 
@@ -65,7 +65,7 @@ describe "apartment rake tasks", database: :postgresql do
 
     describe "apartment:seed" do
       it "should seed all databases" do
-        Apartment::Database.should_receive(:seed).exactly(company_count).times
+        Apartment::Tenant.should_receive(:seed).exactly(company_count).times
 
         @rake['apartment:seed'].invoke
       end

--- a/spec/integration/query_caching_spec.rb
+++ b/spec/integration/query_caching_spec.rb
@@ -10,32 +10,32 @@ describe 'query caching' do
       config.use_schemas = true
     end
 
-    Apartment::Database.reload!(config)
+    Apartment::Tenant.reload!(config)
 
     db_names.each do |db_name|
-      Apartment::Database.create(db_name)
+      Apartment::Tenant.create(db_name)
       Company.create database: db_name
     end
   end
 
   after do
-    db_names.each{ |db| Apartment::Database.drop(db) }
-    Apartment::Database.reset
+    db_names.each{ |db| Apartment::Tenant.drop(db) }
+    Apartment::Tenant.reset
     Company.delete_all
   end
 
   it 'clears the ActiveRecord::QueryCache after switching databases' do
     db_names.each do |db_name|
-      Apartment::Database.switch db_name
+      Apartment::Tenant.switch db_name
       User.create! name: db_name
     end
 
     ActiveRecord::Base.connection.enable_query_cache!
 
-    Apartment::Database.switch db_names.first
+    Apartment::Tenant.switch db_names.first
     User.find_by_name(db_names.first).name.should == db_names.first
 
-    Apartment::Database.switch db_names.last
+    Apartment::Tenant.switch db_names.last
     User.find_by_name(db_names.first).should be_nil
   end
 end

--- a/spec/support/contexts.rb
+++ b/spec/support/contexts.rb
@@ -20,7 +20,7 @@ shared_context "elevators", elevator: true do
   let(:company1)  { mock_model(Company, database: db1).as_null_object }
   let(:company2)  { mock_model(Company, database: db2).as_null_object }
 
-  let(:api)       { Apartment::Database }
+  let(:api)       { Apartment::Tenant }
 
   before do
     Apartment.reset # reset all config

--- a/spec/support/setup.rb
+++ b/spec/support/setup.rb
@@ -15,7 +15,7 @@ module Apartment
           # Otherwise these actually get run after test defined hooks
           around(:each) do |example|
             # before
-            Apartment::Database.reload!(config)
+            Apartment::Tenant.reload!(config)
             ActiveRecord::Base.establish_connection config
 
             example.run
@@ -33,7 +33,7 @@ module Apartment
             end
 
             Apartment.reset
-            Apartment::Database.reload!
+            Apartment::Tenant.reload!
           end
         end
       end

--- a/spec/unit/elevators/domain_spec.rb
+++ b/spec/unit/elevators/domain_spec.rb
@@ -24,7 +24,7 @@ describe Apartment::Elevators::Domain do
 
   describe "#call" do
     it "switches to the proper tenant" do
-      Apartment::Database.should_receive(:switch).with('example')
+      Apartment::Tenant.should_receive(:switch).with('example')
 
       elevator.call('HTTP_HOST' => 'www.example.com')
     end

--- a/spec/unit/elevators/generic_spec.rb
+++ b/spec/unit/elevators/generic_spec.rb
@@ -15,7 +15,7 @@ describe Apartment::Elevators::Generic do
     it "calls the processor if given" do
       elevator = described_class.new(Proc.new{}, Proc.new{'tenant1'})
 
-      Apartment::Database.should_receive(:switch).with('tenant1')
+      Apartment::Tenant.should_receive(:switch).with('tenant1')
 
       elevator.call('HTTP_HOST' => 'foo.bar.com')
     end
@@ -29,7 +29,7 @@ describe Apartment::Elevators::Generic do
     it "switches to the parsed db_name" do
       elevator = MyElevator.new(Proc.new{})
 
-      Apartment::Database.should_receive(:switch).with('tenant2')
+      Apartment::Tenant.should_receive(:switch).with('tenant2')
 
       elevator.call('HTTP_HOST' => 'foo.bar.com')
     end

--- a/spec/unit/elevators/host_hash_spec.rb
+++ b/spec/unit/elevators/host_hash_spec.rb
@@ -24,7 +24,7 @@ describe Apartment::Elevators::HostHash do
 
   describe "#call" do
     it "switches to the proper tenant" do
-      Apartment::Database.should_receive(:switch).with('example_tenant')
+      Apartment::Tenant.should_receive(:switch).with('example_tenant')
 
       elevator.call('HTTP_HOST' => 'example.com')
     end

--- a/spec/unit/elevators/subdomain_spec.rb
+++ b/spec/unit/elevators/subdomain_spec.rb
@@ -39,14 +39,14 @@ describe Apartment::Elevators::Subdomain do
 
   describe "#call" do
     it "switches to the proper tenant" do
-      Apartment::Database.should_receive(:switch).with('tenant1')
+      Apartment::Tenant.should_receive(:switch).with('tenant1')
       elevator.call('HTTP_HOST' => 'tenant1.example.com')
     end
 
     it "ignores excluded subdomains" do
       described_class.excluded_subdomains = %w{foo}
 
-      Apartment::Database.should_not_receive(:switch)
+      Apartment::Tenant.should_not_receive(:switch)
 
       elevator.call('HTTP_HOST' => 'foo.bar.com')
 

--- a/spec/unit/migrator_spec.rb
+++ b/spec/unit/migrator_spec.rb
@@ -6,11 +6,11 @@ describe Apartment::Migrator do
   let(:tenant){ Apartment::Test.next_db }
 
   # Don't need a real switch here, just testing behaviour
-  before { Apartment::Database.adapter.stub(:connect_to_new) }
+  before { Apartment::Tenant.adapter.stub(:connect_to_new) }
 
   describe "::migrate" do
     it "processes and migrates" do
-      expect(Apartment::Database).to receive(:process).with(tenant).and_call_original
+      expect(Apartment::Tenant).to receive(:process).with(tenant).and_call_original
       expect(ActiveRecord::Migrator).to receive(:migrate)
 
       Apartment::Migrator.migrate(tenant)
@@ -19,7 +19,7 @@ describe Apartment::Migrator do
 
   describe "::run" do
     it "processes and runs" do
-      expect(Apartment::Database).to receive(:process).with(tenant).and_call_original
+      expect(Apartment::Tenant).to receive(:process).with(tenant).and_call_original
       expect(ActiveRecord::Migrator).to receive(:run).with(:up, anything, 1234)
 
       Apartment::Migrator.run(:up, tenant, 1234)
@@ -28,7 +28,7 @@ describe Apartment::Migrator do
 
   describe "::rollback" do
     it "processes and rolls back" do
-      expect(Apartment::Database).to receive(:process).with(tenant).and_call_original
+      expect(Apartment::Tenant).to receive(:process).with(tenant).and_call_original
       expect(ActiveRecord::Migrator).to receive(:rollback).with(anything, 2)
 
       Apartment::Migrator.rollback(tenant, 2)

--- a/spec/unit/reloader_spec.rb
+++ b/spec/unit/reloader_spec.rb
@@ -9,7 +9,7 @@ describe Apartment::Reloader do
         config.excluded_models = ["Company"]
         config.use_schemas = true
       end
-      Apartment::Database.reload!(config)
+      Apartment::Tenant.reload!(config)
       Company.reset_table_name  # ensure we're clean
     end
 


### PR DESCRIPTION
Ground work done. I'm still a bit confused at old exception messages, like one below:

```
rescue *rescuable_exceptions
  raise DatabaseNotFound, "The tenant #{tenant} cannot be found"`
end
```

How to revise it to the new abstraction? @bradrobertson
