### PR TITLE
Note on Heroku’s regenerated database.yml file that causes schema_search_path to be the default \”$user\",public

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ schema_search_path: "public,hstore"
 ...
 ```
 
-This would be for a config with `default_schema` set to `public` and `persistent_schemas` set to `['hstore']`
+This would be for a config with `default_schema` set to `public` and `persistent_schemas` set to `['hstore']`. **Note**: This doesn't work if you use Heroku because for each deploy, Heroku regenerates `database.yml` completely different and your predefined `schema_search_path` will be deleted. ActiveRecord's `schema_search_path` will be the default `\"$user\",public`.
 
 Another way that we've successfully configured hstore for our applications is to add it into the
 postgresql template1 database so that every tenant that gets created has it by default.


### PR DESCRIPTION
Here is how `database.yml` looks like on Heroku after each deploy: https://gist.github.com/4e4dcfafc8bab305e6f0

The new file doesn't have the extra `schema_search_path` as defined locally. Quick check in the console to validate that custom `schema_search_path` is not set:

``` ruby
Apartment.connection.schema_search_path
=> "\"$user\",public"
```

It takes me a few days to debug this out so I guess it's worth mentioning this upfront for people who use Heroku :).
