### PR TITLE
Update README to explain Heroku support for persistent schema's.

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ schema_search_path: "public,hstore"
 ...
 ```
 
-This would be for a config with `default_schema` set to `public` and `persistent_schemas` set to `['hstore']`. **Note**: This doesn't work if you use Heroku because for each deploy, Heroku regenerates `database.yml` completely different and your predefined `schema_search_path` will be deleted. ActiveRecord's `schema_search_path` will be the default `\"$user\",public`.
+This would be for a config with `default_schema` set to `public` and `persistent_schemas` set to `['hstore']`. **Note**: This only works on Heroku with [Rails 4.1+](https://devcenter.heroku.com/changelog-items/427). For older Rails versions Heroku regenerates a completely different `database.yml` for each deploy and your predefined `schema_search_path` will be deleted. ActiveRecord's `schema_search_path` will be the default `\"$user\",public`.
 
 Another way that we've successfully configured hstore for our applications is to add it into the
 postgresql template1 database so that every tenant that gets created has it by default.


### PR DESCRIPTION
Since Rails 4.1 the database.yml isn't completely overwritten which enables an easy solution for persistent schema's on Heroku. See Heroku changelog item: https://devcenter.heroku.com/changelog-items/426
