### PR TITLE
Made schema based MySQL2 adapter the default (#153)

### DIFF
--- a/apartment.gemspec
+++ b/apartment.gemspec
@@ -24,8 +24,9 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'appraisal'
   s.add_development_dependency 'rake',         '~> 0.9'
   s.add_development_dependency 'rspec-rails',  '~> 2.14'
+  s.add_development_dependency 'rspec-its'
   s.add_development_dependency 'guard-rspec',  '~> 4.2'
-  s.add_development_dependency 'capybara',     '~> 1.0.0'
+  s.add_development_dependency 'capybara'
 
   if defined?(JRUBY_VERSION)
     s.add_development_dependency 'activerecord-jdbc-adapter'

--- a/lib/apartment.rb
+++ b/lib/apartment.rb
@@ -10,7 +10,7 @@ module Apartment
 
     extend Forwardable
 
-    ACCESSOR_METHODS  = [:use_schemas, :use_sql, :seed_after_create, :prepend_environment, :append_environment]
+    ACCESSOR_METHODS  = [:use_schemas, :use_sql, :use_mysql2_swap_connection_pool_strategy, :seed_after_create, :prepend_environment, :append_environment]
     WRITER_METHODS    = [:tenant_names, :database_schema_file, :excluded_models, :default_schema, :persistent_schemas, :connection_class, :tld_length, :db_migrate_tenants]
 
     attr_accessor(*ACCESSOR_METHODS)

--- a/lib/apartment/adapters/mysql2_adapter.rb
+++ b/lib/apartment/adapters/mysql2_adapter.rb
@@ -4,32 +4,35 @@ module Apartment
   module Database
 
     def self.mysql2_adapter(config)
-      Apartment.use_schemas ?
-        Adapters::Mysql2SchemaAdapter.new(config) :
+      Apartment.use_mysql2_swap_connection_pool_strategy ?
+        Adapters::SwapConnectionPoolStrategy::Mysql2Adapter.new(config) :
         Adapters::Mysql2Adapter.new(config)
     end
   end
 
   module Adapters
-    class Mysql2Adapter < AbstractAdapter
 
-    protected
+    module SwapConnectionPoolStrategy
+      class Mysql2Adapter < AbstractAdapter
 
-      #   Connect to new tenant
-      #   Abstract adapter will catch generic ActiveRecord error
-      #   Catch specific adapter errors here
-      #
-      #   @param {String} tenant Tenant name
-      #
-      def connect_to_new(tenant = nil)
-        super
-      rescue Mysql2::Error
-        Apartment::Database.reset
-        raise DatabaseNotFound, "Cannot find tenant #{environmentify(tenant)}"
+      protected
+
+        #   Connect to new tenant
+        #   Abstract adapter will catch generic ActiveRecord error
+        #   Catch specific adapter errors here
+        #
+        #   @param {String} tenant Tenant name
+        #
+        def connect_to_new(tenant = nil)
+          super
+        rescue Mysql2::Error
+          Apartment::Database.reset
+          raise DatabaseNotFound, "Cannot find tenant #{environmentify(tenant)}"
+        end
       end
     end
 
-    class Mysql2SchemaAdapter < AbstractAdapter
+    class Mysql2Adapter < AbstractAdapter
       attr_reader :default_tenant
 
       def initialize(config)

--- a/spec/adapters/mysql2_adapter_spec.rb
+++ b/spec/adapters/mysql2_adapter_spec.rb
@@ -13,7 +13,7 @@ describe Apartment::Adapters::Mysql2Adapter, database: :mysql do
     let(:default_tenant) { subject.process { ActiveRecord::Base.connection.current_database } }
 
     context "using - the equivalent of - schemas" do
-      before { Apartment.use_schemas = true }
+      before { Apartment.use_mysql2_swap_connection_pool_strategy = false }
 
       it_should_behave_like "a generic apartment adapter"
 
@@ -39,7 +39,7 @@ describe Apartment::Adapters::Mysql2Adapter, database: :mysql do
     end
 
     context "using connections" do
-      before { Apartment.use_schemas = false }
+      before { Apartment.use_mysql2_swap_connection_pool_strategy = true }
 
       it_should_behave_like "a generic apartment adapter"
       it_should_behave_like "a connection based apartment adapter"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,7 @@ ENV["RAILS_ENV"] = "test"
 
 require File.expand_path("../dummy/config/environment.rb", __FILE__)
 require "rspec/rails"
+require "rspec/its"
 require 'capybara/rspec'
 require 'capybara/rails'
 
@@ -24,6 +25,8 @@ Rails.backtrace_cleaner.remove_silencers!
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
 
 RSpec.configure do |config|
+
+  config.infer_spec_type_from_file_location!
 
   config.include RSpec::Integration::CapybaraSessions, type: :request
   config.include Apartment::Spec::Setup

--- a/spec/support/setup.rb
+++ b/spec/support/setup.rb
@@ -26,7 +26,7 @@ module Apartment
 
             Apartment.excluded_models.each do |model|
               klass = model.constantize
-              
+
               Apartment.connection_class.remove_connection(klass)
               klass.clear_all_connections!
               klass.reset_table_name
@@ -39,7 +39,7 @@ module Apartment
       end
 
       def database_config
-        db = example.metadata.fetch(:database, :postgresql)
+        db = RSpec.current_example.metadata.fetch(:database, :postgresql)
         Apartment::Test.config['connections'][db.to_s].symbolize_keys
       end
     end

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -25,7 +25,7 @@ describe Apartment do
         config.excluded_models = []
         config.use_schemas = false
       end
-      Apartment.use_schemas.should be_false
+      Apartment.use_schemas.should be false
     end
 
     it "should set seed_after_create" do
@@ -33,7 +33,7 @@ describe Apartment do
         config.excluded_models = []
         config.seed_after_create = true
       end
-      Apartment.seed_after_create.should be_true
+      Apartment.seed_after_create.should be true
     end
 
     it "should set tld_length" do


### PR DESCRIPTION
Updated the MySQL2 adapter to use the schema based version by default
even when `use_schema` is disabled.

Using the connection based adapter is causing abandoned connections
with the current mysql2 gem.

NOTE: I also updated the specs to rspec3 style.
