### PR TITLE
Fix schema migrations for tenants using sql creation

### DIFF
--- a/lib/apartment/adapters/postgresql_adapter.rb
+++ b/lib/apartment/adapters/postgresql_adapter.rb
@@ -148,8 +148,6 @@ module Apartment
       #   @return {String} raw SQL contaning only postgres schema dump
       #
       def pg_dump_schema
-        dbname = ActiveRecord::Base.connection_config[:database]
-        default_schema = Apartment.default_schema
 
         # Skip excluded tables? :/
         # excluded_tables =
@@ -167,7 +165,7 @@ module Apartment
       #   @return {String} raw SQL contaning inserts with data from schema_migrations
       #
       def pg_dump_schema_migrations_data
-        `pg_dump -a --inserts -t schema_migrations -n #{Apartment.default_schema} bithub_development`
+        `pg_dump -a --inserts -t schema_migrations -n #{default_schema} #{dbname}`
       end
 
       #   Remove "SET search_path ..." line from SQL dump and prepend search_path set to current tenant
@@ -196,6 +194,18 @@ module Apartment
         models.map do |m|
           m.constantize.table_name
         end
+      end
+
+      # Convenience method for current database name
+      #
+      def dbname 
+        ActiveRecord::Base.connection_config[:database]
+      end
+
+      # Convenience method for the default schema
+      #
+      def default_schema 
+        Apartment.default_schema
       end
 
     end


### PR DESCRIPTION
Remove hardcoded reference to 'bithub_development'

I know there is still discussion on the best way to handle excluded models with the tenant creation from SQL feature [here](https://github.com/influitive/apartment/pull/128#issuecomment-47089646). However, in the meantime it would be great to at least fix this error so the development does not have fatal database messages and works for tenant migrations.

I would have liked to have added some regression tests but I am not sure how to create specs for this code-base. I am open to suggestions. I real integration test would have been to run a new migration somehow and show that it gets recorded in the tenant schema_migrations. I am open to ideas. 
