### PR TITLE
don't initialize Apartment during assets:precompile

### DIFF
--- a/lib/apartment/railtie.rb
+++ b/lib/apartment/railtie.rb
@@ -28,7 +28,7 @@ module Apartment
     #   See the middleware/console declarations below to help with this. Hope to fix that soon.
     #
     config.to_prepare do
-      Apartment::Tenant.init
+      Apartment::Tenant.init unless ARGV.include? 'assets:precompile'
     end
 
     #


### PR DESCRIPTION
should fix #106. Additionally, this should also fix the problem for anyone not using heroku but using a separate build/deploy process where the build environment doesn't have access to a database.
