### PR TITLE
Retrieve connection through Apartment module

### DIFF
--- a/lib/apartment.rb
+++ b/lib/apartment.rb
@@ -17,7 +17,7 @@ module Apartment
     attr_accessor(*ACCESSOR_METHODS)
     attr_writer(*WRITER_METHODS)
 
-    def_delegators :connection_class, :connection, :establish_connection
+    def_delegators :connection_class, :connection, :connection_config, :establish_connection
 
     # configure apartment with available options
     def configure

--- a/lib/apartment/adapters/abstract_adapter.rb
+++ b/lib/apartment/adapters/abstract_adapter.rb
@@ -82,7 +82,7 @@ module Apartment
         return reset if tenant.nil?
 
         connect_to_new(tenant).tap do
-          ActiveRecord::Base.connection.clear_query_cache
+          Apartment.connection.clear_query_cache
         end
       end
 

--- a/lib/apartment/adapters/postgresql_adapter.rb
+++ b/lib/apartment/adapters/postgresql_adapter.rb
@@ -199,7 +199,7 @@ module Apartment
       # Convenience method for current database name
       #
       def dbname
-        ActiveRecord::Base.connection_config[:database]
+        Apartment.connection_config[:database]
       end
     end
   end

--- a/lib/apartment/tenant.rb
+++ b/lib/apartment/tenant.rb
@@ -61,8 +61,7 @@ module Apartment
     #   Fetch the rails database configuration
     #
     def config
-      @config ||= (ActiveRecord::Base.configurations[Rails.env] ||
-                    Rails.application.config.database_configuration[Rails.env]).symbolize_keys
+      @config ||= Apartment.connection_config
     end
   end
 


### PR DESCRIPTION
In some places the connection and connection related things were being accessed directly through `ActiveRecord::Base` instead of `Apartment.connection_class`.