### PR TITLE
Check how this is doing on JRuby head

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,9 @@ env:
   RUBY_GC_MALLOC_LIMIT: 90000000
   RUBY_FREE_MIN: 200000
 matrix:
+  allow_failures:
+    - rvm: jruby-head
   exclude:
     - rvm: 2.2.0
       gemfile: gemfiles/rails_3_2.gemfile
+  fast_finish: true


### PR DESCRIPTION
Since a preview build is now available for JRuby 9000 it's interesting to see how this is doing on jruby-head.

I've added `jruby-head` to `allow_failures`, so it won't mark the whole build as failed if it just fails for `jruby-head`.

Docs: http://docs.travis-ci.com/user/build-configuration/