### PR TITLE
Correct command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ One can optionally use the full database creation instead if they want, though t
 To switch tenants using Apartment, use the following command:
 
 ```ruby
-Apartment::Tenant.switch!('tenant_name')
+Apartment::Tenant.switch('tenant_name')
 ```
 
 When switch is called, all requests coming to ActiveRecord will be routed to the tenant


### PR DESCRIPTION
Every time I've used this gem, I always have to use `switch()` instead of `switch!()`. This leads me to believe that this is a typo in the README - correct me if I'm wrong :)