### PR TITLE
Adds seed_data_file config option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ spec/dummy/config/database.yml
 cookbooks
 tmp
 spec/dummy/db/*.sqlite3
+.DS_Store

--- a/lib/apartment.rb
+++ b/lib/apartment.rb
@@ -12,7 +12,7 @@ module Apartment
     extend Forwardable
 
     ACCESSOR_METHODS  = [:use_schemas, :use_sql, :seed_after_create, :prepend_environment, :append_environment]
-    WRITER_METHODS    = [:tenant_names, :database_schema_file, :excluded_models, :default_schema, :persistent_schemas, :connection_class, :tld_length, :db_migrate_tenants]
+    WRITER_METHODS    = [:tenant_names, :database_schema_file, :excluded_models, :default_schema, :persistent_schemas, :connection_class, :tld_length, :db_migrate_tenants, :seed_data_file]
 
     attr_accessor(*ACCESSOR_METHODS)
     attr_writer(*WRITER_METHODS)
@@ -60,6 +60,12 @@ module Apartment
       return @database_schema_file if defined?(@database_schema_file)
 
       @database_schema_file = Rails.root.join('db', 'schema.rb')
+    end
+
+    def seed_data_file
+      return @seed_data_file if defined?(@seed_data_file)
+
+      @seed_data_file = "#{Rails.root}/db/seeds.rb"
     end
 
     def tld_length

--- a/lib/apartment/adapters/abstract_adapter.rb
+++ b/lib/apartment/adapters/abstract_adapter.rb
@@ -138,7 +138,8 @@ module Apartment
       #   Load the rails seed file into the db
       #
       def seed_data
-        silence_stream(STDOUT){ load_or_abort("#{Rails.root}/db/seeds.rb") } # Don't log the output of seeding the db
+        # Don't log the output of seeding the db
+        silence_stream(STDOUT){ load_or_abort(Apartment.seed_data_file) } if Apartment.seed_data_file
       end
       alias_method :seed, :seed_data
 

--- a/spec/dummy/db/seeds/import.rb
+++ b/spec/dummy/db/seeds/import.rb
@@ -1,0 +1,5 @@
+def create_users
+  6.times {|x| User.where(name: "Different User #{x}").first_or_create! }
+end
+
+create_users

--- a/spec/tenant_spec.rb
+++ b/spec/tenant_spec.rb
@@ -150,5 +150,34 @@ describe Apartment::Tenant do
         end
       end
     end
+
+    context "seed paths" do
+      before do
+        Apartment.configure do |config|
+          config.excluded_models = []
+          config.use_schemas = true
+          config.seed_after_create = true
+        end
+      end
+
+      after{ subject.drop db1 }
+
+      it 'should seed from default path' do
+        subject.create db1
+        subject.switch! db1
+        User.count.should eq(3)
+        User.first.name.should eq('Some User 0')
+      end
+
+      it 'should seed from custom path' do
+        Apartment.configure do |config|
+          config.seed_data_file = "#{Rails.root}/db/seeds/import.rb"
+        end
+        subject.create db1
+        subject.switch! db1
+        User.count.should eq(6)
+        User.first.name.should eq('Different User 0')
+      end
+    end
   end
 end

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -5,6 +5,7 @@ describe Apartment do
   describe "#config" do
 
     let(:excluded_models){ ["Company"] }
+    let(:seed_data_file_path){ "#{Rails.root}/db/seeds/import.rb" }
 
     it "should yield the Apartment object" do
       Apartment.configure do |config|
@@ -26,6 +27,13 @@ describe Apartment do
         config.use_schemas = false
       end
       Apartment.use_schemas.should be false
+    end
+
+    it "should set seed_data_file" do
+      Apartment.configure do |config|
+        config.seed_data_file = seed_data_file_path
+      end
+      Apartment.seed_data_file.should eq(seed_data_file_path)
     end
 
     it "should set seed_after_create" do


### PR DESCRIPTION
Allows implementors to specify a path to seed data file. Falls back to standard Rails seed path.

* Adds test to ensure seed_data_file path is set.
* Add tests to ensure seeds are correctly imported.
* Ignore .DS_Store files.