### PR TITLE
Use ActionDispatch tld_length by default

### DIFF
--- a/lib/apartment.rb
+++ b/lib/apartment.rb
@@ -69,7 +69,7 @@ module Apartment
     end
 
     def tld_length
-      @tld_length || 1
+      @tld_length || Rails.application.config.action_dispatch.tld_length
     end
 
     # Reset all the config for Apartment


### PR DESCRIPTION
Instead of having a top level domain variable set in the apartment configuration the gem can get it from the Rails application config.

It might be better to deprecate ```tld_length``` in favour of ```Rails.application.config.action_dispatch.tld_length```. I'm happy to do that if you agree with it.