### PR TITLE
Apartment.tenant_name

### DIFF
--- a/lib/apartment.rb
+++ b/lib/apartment.rb
@@ -12,7 +12,7 @@ module Apartment
     extend Forwardable
 
     ACCESSOR_METHODS  = [:use_schemas, :use_sql, :seed_after_create, :prepend_environment, :append_environment]
-    WRITER_METHODS    = [:tenant_names, :database_schema_file, :excluded_models, :default_schema, :persistent_schemas, :connection_class, :tld_length, :db_migrate_tenants, :seed_data_file]
+    WRITER_METHODS    = [:tenant_names, :tenant_name, :database_schema_file, :excluded_models, :default_schema, :persistent_schemas, :connection_class, :tld_length, :db_migrate_tenants, :seed_data_file]
 
     attr_accessor(*ACCESSOR_METHODS)
     attr_writer(*WRITER_METHODS)
@@ -27,6 +27,10 @@ module Apartment
     # Be careful not to use `return` here so both Proc and lambda can be used without breaking
     def tenant_names
       @tenant_names.respond_to?(:call) ? @tenant_names.call : @tenant_names
+    end
+
+    def tenant_name(name)
+      @tenant_name.respond_to?(:call) ? @tenant_name.call(name) : name
     end
 
     # Whether or not db:migrate should also migrate tenants

--- a/lib/apartment/adapters/abstract_adapter.rb
+++ b/lib/apartment/adapters/abstract_adapter.rb
@@ -143,7 +143,7 @@ module Apartment
       end
       alias_method :seed, :seed_data
 
-    protected
+      protected
 
       #   Create the tenant
       #
@@ -168,29 +168,30 @@ module Apartment
         raise TenantNotFound, "The tenant #{environmentify(tenant)} cannot be found."
       end
 
-      #   Prepend the environment if configured and the environment isn't already there
+      #   Process through config.tenant_name if set and Prepend the environment
+      #   if configured and the environment isn't already there.
       #
       #   @param {String} tenant Database name
       #   @return {String} tenant name with Rails environment *optionally* prepended
       #
       def environmentify(tenant)
-        unless tenant.include?(Rails.env)
-          if Apartment.prepend_environment
-            "#{Rails.env}_#{tenant}"
-          elsif Apartment.append_environment
-            "#{tenant}_#{Rails.env}"
-          else
-            tenant
-          end
-        else
-          tenant
+        tenant = Apartment.tenant_name(tenant)
+        environmentify_name(tenant) || tenant
+      end
+
+      def environmentify_name(tenant)
+        return if tenant.include?(Rails.env)
+        if Apartment.prepend_environment
+          "#{Rails.env}_#{tenant}"
+        elsif Apartment.append_environment
+          "#{tenant}_#{Rails.env}"
         end
       end
 
       #   Import the database schema
       #
       def import_database_schema
-        ActiveRecord::Schema.verbose = false    # do not log schema load output.
+        ActiveRecord::Schema.verbose = false # do not log schema load output.
 
         load_or_abort(Apartment.database_schema_file) if Apartment.database_schema_file
       end
@@ -206,7 +207,7 @@ module Apartment
       #   Load a file or abort if it doesn't exists
       #
       def load_or_abort(file)
-        if File.exists?(file)
+        if File.exist?(file)
           load(file)
         else
           abort %{#{file} doesn't exist yet}

--- a/lib/generators/apartment/install/templates/apartment.rb
+++ b/lib/generators/apartment/install/templates/apartment.rb
@@ -26,6 +26,11 @@ Apartment.configure do |config|
   #
   config.tenant_names = lambda { ToDo_Tenant_Or_User_Model.pluck :database }
 
+  # In order to amend tenant database names or prefix them with your
+  # application name you can set up the transformation as follows.
+  #
+  # config.tenant_name = lambda { |name| "application_#{name}" }
+
   #
   # ==> PostgreSQL only options
 

--- a/spec/dummy/config/environments/development.rb
+++ b/spec/dummy/config/environments/development.rb
@@ -13,7 +13,7 @@ Dummy::Application.configure do
 
   # Show full error reports and disable caching
   config.consider_all_requests_local       = true
-  config.action_view.debug_rjs             = true
+  # config.action_view.debug_rjs             = true
   config.action_controller.perform_caching = false
 
   # Don't care if the mailer can't send
@@ -25,4 +25,3 @@ Dummy::Application.configure do
   # Only use best-standards-support built into browsers
   config.action_dispatch.best_standards_support = :builtin
 end
-

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -85,5 +85,19 @@ describe Apartment do
       end
     end
 
+    context "tenant_name" do
+      it "should return tenant_name as is" do
+        expect(Apartment.tenant_name('name')).to eq 'name'
+      end
+
+      it "should invoke the proc if appropriate" do
+        tenant_name = lambda { |name| "prefix_#{name}" }
+
+        Apartment.configure do |config|
+          config.tenant_name = tenant_name
+        end
+        expect(Apartment.tenant_name("name")).to eq "prefix_name"
+      end
+    end
   end
 end


### PR DESCRIPTION
https://github.com/influitive/apartment/issues/254

In order to amend tenant database names or prefix them with your
application name you can set up the transformation as follows.

```ruby
config.tenant_name = -> name { "application_#{name}" }
```

This transformation happens before `append/prepend` so if you have `motivation` and `motivaition_client` in production, it will be `motivation_development` and `motivation_client_development` which sounds logical to me.