### PR TITLE
Elevator middleware needs to run before ActiveRecord management

### DIFF
--- a/lib/generators/apartment/install/templates/apartment.rb
+++ b/lib/generators/apartment/install/templates/apartment.rb
@@ -60,10 +60,10 @@ end
 
 # Setup a custom Tenant switching middleware. The Proc should return the name of the Tenant that
 # you want to switch to.
-# Rails.application.config.middleware.use 'Apartment::Elevators::Generic', lambda { |request|
+# Rails.application.config.middleware.insert_before ActiveRecord::ConnectionAdapters::ConnectionManagement, 'Apartment::Elevators::Generic', lambda { |request|
 #   request.host.split('.').first
 # }
 
-# Rails.application.config.middleware.use 'Apartment::Elevators::Domain'
-Rails.application.config.middleware.use 'Apartment::Elevators::Subdomain'
-# Rails.application.config.middleware.use 'Apartment::Elevators::FirstSubdomain'
+# Rails.application.config.middleware.insert_before ActiveRecord::ConnectionAdapters::ConnectionManagement, 'Apartment::Elevators::Domain'
+Rails.application.config.middleware.insert_before ActiveRecord::ConnectionAdapters::ConnectionManagement, 'Apartment::Elevators::Subdomain'
+# Rails.application.config.middleware.insert_before ActiveRecord::ConnectionAdapters::ConnectionManagement, 'Apartment::Elevators::FirstSubdomain'


### PR DESCRIPTION
Right now, if you have a tenant foo at foo.domain.com, and NO existing tenant named bar, the following occurs when accessing the two subdomains:
1. Visit foo.domain.com -> OK
2. Visit bar.domain.com -> Expected error occurs
3. Revisit foo.domain.com -> Unexpected error: FATAL: database "bar" does not exist

ActiveRecord's middleware tries to load the previous, cached invalid db connection, which it does before Apartment middleware even has a chance to switch to a new tenant.  (This is with use_schemas = false).

The solution is to simply run Apartment middleware before ActiveRecord's connection manager.
