### PR TITLE
Fixes for #180

### DIFF
--- a/lib/apartment.rb
+++ b/lib/apartment.rb
@@ -17,7 +17,7 @@ module Apartment
     attr_accessor(*ACCESSOR_METHODS)
     attr_writer(*WRITER_METHODS)
 
-    def_delegators :connection_class, :connection, :connection_config, :establish_connection
+    def_delegators :connection_class, :connection, :connection_handler, :connection_handler=, :connection_config, :establish_connection
 
     # configure apartment with available options
     def configure

--- a/lib/apartment/adapters/mysql2_adapter.rb
+++ b/lib/apartment/adapters/mysql2_adapter.rb
@@ -17,6 +17,8 @@ module Apartment
         super
 
         @default_tenant = config[:database]
+        Apartment.connection_handler = ActiveRecord::ConnectionAdapters::ConnectionHandler.new
+        reset
       end
 
     protected

--- a/lib/apartment/adapters/postgresql_adapter.rb
+++ b/lib/apartment/adapters/postgresql_adapter.rb
@@ -15,6 +15,13 @@ module Apartment
     # Default adapter when not using Postgresql Schemas
     class PostgresqlAdapter < AbstractAdapter
 
+      def initialize(config)
+        super
+
+        Apartment.connection_handler = ActiveRecord::ConnectionAdapters::ConnectionHandler.new
+        reset
+      end
+
       def drop(tenant)
         # Apartment.connection.drop_database note that drop_database will not throw an exception, so manually execute
         Apartment.connection.execute(%{DROP DATABASE "#{tenant}"})

--- a/lib/apartment/adapters/postgresql_adapter.rb
+++ b/lib/apartment/adapters/postgresql_adapter.rb
@@ -43,6 +43,7 @@ module Apartment
       def initialize(config)
         super
 
+        Apartment.establish_connection(config)
         reset
       end
 

--- a/lib/apartment/adapters/sqlite3_adapter.rb
+++ b/lib/apartment/adapters/sqlite3_adapter.rb
@@ -13,6 +13,9 @@ module Apartment
         @default_dir = File.expand_path(File.dirname(config[:database]))
 
         super
+
+        Apartment.connection_handler = ActiveRecord::ConnectionAdapters::ConnectionHandler.new
+        reset
       end
 
       def drop(tenant)


### PR DESCRIPTION
The problem: with connection-based adapters (adapters that use
`establish_connection`) switching the tenant in one thread would
switch it for all other threads. This is because of how AR's
connection handler stores a global connection pool to class name
mapping.

The solution: AR has a strange way that you can override the
connection handler _for the local thread_, by calling the
`connection_handler=` setter. This will means that threads don't
share a connection pool, so there will be more connections
(threads*pool_size), but it means that we can use separate
connection pool per thread allowing us to use
`establish_connection` safely.