### PR TITLE
Adding nil check in parse_tenant_name for FirstSubdomain Elevator

### DIFF
--- a/lib/apartment/elevators/first_subdomain.rb
+++ b/lib/apartment/elevators/first_subdomain.rb
@@ -10,7 +10,7 @@ module Apartment
     class FirstSubdomain < Subdomain
 
       def parse_tenant_name(request)
-        super.split('.')[0]
+        super.split('.')[0] unless super.nil?
       end
     end
   end

--- a/spec/unit/elevators/first_subdomain_spec.rb
+++ b/spec/unit/elevators/first_subdomain_spec.rb
@@ -15,5 +15,10 @@ describe Apartment::Elevators::FirstSubdomain do
       let(:subdomain) { "test1.test2" }
       it { should == "test1" }
     end
+    
+    context "no subdomain" do
+      let(:subdomain) { nil }
+      it { should == nil }
+    end
   end
 end


### PR DESCRIPTION

When using the FirstSubDomain elevator when the super was nil it generated an error to occur. This will now return nil if super is nil. 

