### PR TITLE
Custom connection options for tenants (basically to store on different servers) #264 #269 #270

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,6 +416,33 @@ and test environments.  If you wish to turn this option off in production, you c
 config.prepend_environment = !Rails.env.production?
 ```
 
+## Tenants on different servers
+
+You can store your tenants in different databases on one or more servers.
+To do it, specify your `tenant_names` as a hash, keys being the actual tenant names,
+values being a hash with the database configuration to use.
+
+Example:
+
+```ruby
+config.tenant_names = {
+  'tenant1' => {
+    adapter: 'postgresql',
+    host: 'some_server',
+    port: 5555,
+    database: 'postgres' # this is not the name of the tenant's db
+                         # but the name of the database to connect to, before creating the tenant's db
+                         # mandatory in postgresql
+  }
+}
+# or using a lambda:
+config.tenant_names = lambda do
+  Tenant.all.each_with_object({}) do |tenant, hash|
+    hash[tenant.name] = tenant.db_configuration
+  end
+end
+```
+
 ## Delayed::Job
 ### Has been removed... See apartment-sidekiq for a better backgrounding experience
 

--- a/lib/apartment/adapters/abstract_jdbc_adapter.rb
+++ b/lib/apartment/adapters/abstract_jdbc_adapter.rb
@@ -4,16 +4,11 @@ module Apartment
   module Adapters
     class AbstractJDBCAdapter < AbstractAdapter
 
-    protected
-
-      #   Return a new config that is multi-tenanted
-      #
-      def multi_tenantify(database)
-        @config.clone.tap do |config|
-          config[:url] = "#{config[:url].gsub(/(\S+)\/.+$/, '\1')}/#{environmentify(database)}"
-        end
-      end
     private
+
+      def multi_tenantify_with_tenant_db_name(config, tenant)
+        config[:url] = "#{config[:url].gsub(/(\S+)\/.+$/, '\1')}/#{environmentify(tenant)}"
+      end
 
       def rescue_from
         ActiveRecord::JDBCError

--- a/lib/apartment/adapters/jdbc_mysql_adapter.rb
+++ b/lib/apartment/adapters/jdbc_mysql_adapter.rb
@@ -11,19 +11,8 @@ module Apartment
   module Adapters
     class JDBCMysqlAdapter < AbstractJDBCAdapter
 
-      protected
-
-      #   Connect to new database
-      #   Abstract adapter will catch generic ActiveRecord error
-      #   Catch specific adapter errors here
-      #
-      #   @param {String} database Database name
-      #
-      def connect_to_new(database)
-        super
-      rescue TenantNotFound
-        Apartment::Tenant.reset
-        raise TenantNotFound, "Cannot find database #{environmentify(database)}"
+      def reset_on_connection_exception?
+        true
       end
     end
   end

--- a/lib/apartment/adapters/jdbc_postgresql_adapter.rb
+++ b/lib/apartment/adapters/jdbc_postgresql_adapter.rb
@@ -15,26 +15,15 @@ module Apartment
     # Default adapter when not using Postgresql Schemas
     class JDBCPostgresqlAdapter < PostgresqlAdapter
 
-    protected
-
-      def create_tenant(tenant)
-        # There is a bug in activerecord-jdbcpostgresql-adapter (1.2.5) that will cause
-        # an exception if no options are passed into the create_database call.
-        Apartment.connection.create_database(environmentify(tenant), { :thisisahack => '' })
-
-      rescue *rescuable_exceptions
-        raise TenantExists, "The tenant #{environmentify(tenant)} already exists."
-      end
-
-      #   Return a new config that is multi-tenanted
-      #
-      def multi_tenantify(tenant)
-        @config.clone.tap do |config|
-          config[:url] = "#{config[:url].gsub(/(\S+)\/.+$/, '\1')}/#{environmentify(tenant)}"
-        end
-      end
-
     private
+
+      def multi_tenantify_with_tenant_db_name(config, tenant)
+        config[:url] = "#{config[:url].gsub(/(\S+)\/.+$/, '\1')}/#{environmentify(tenant)}"
+      end
+
+      def create_tenant_command(conn, tenant)
+        conn.create_database(environmentify(tenant), { :thisisahack => '' })
+      end
 
       def rescue_from
         ActiveRecord::JDBCError

--- a/lib/generators/apartment/install/templates/apartment.rb
+++ b/lib/generators/apartment/install/templates/apartment.rb
@@ -19,10 +19,33 @@ Apartment.configure do |config|
 
   # In order to migrate all of your Tenants you need to provide a list of Tenant names to Apartment.
   # You can make this dynamic by providing a Proc object to be called on migrations.
-  # This object should yield an array of strings representing each Tenant name.
+  # This object should yield either:
+  # - an array of strings representing each Tenant name.
+  # - a hash which keys are tenant names, and values custom db config (must contain all key/values required in database.yml)
   #
   # config.tenant_names = lambda{ Customer.pluck(:tenant_name) }
   # config.tenant_names = ['tenant1', 'tenant2']
+  # config.tenant_names = {
+  #   'tenant1' => {
+  #     adapter: 'postgresql',
+  #     host: 'some_server',
+  #     port: 5555,
+  #     database: 'postgres' # this is not the name of the tenant's db
+  #                          # but the name of the database to connect to before creating the tenant's db
+  #                          # mandatory in postgresql
+  #   },
+  #   'tenant2' => {
+  #     adapter:  'postgresql',
+  #     database: 'postgres' # this is not the name of the tenant's db
+  #                          # but the name of the database to connect to before creating the tenant's db
+  #                          # mandatory in postgresql
+  #   }
+  # }
+  # config.tenant_names = lambda do
+  #   Tenant.all.each_with_object({}) do |tenant, hash|
+  #     hash[tenant.name] = tenant.db_configuration
+  #   end
+  # end
   #
   config.tenant_names = lambda { ToDo_Tenant_Or_User_Model.pluck :database }
 

--- a/lib/tasks/apartment.rake
+++ b/lib/tasks/apartment.rake
@@ -17,7 +17,6 @@ apartment_namespace = namespace :apartment do
   desc "Migrate all tenants"
   task :migrate do
     warn_if_tenants_empty
-
     tenants.each do |tenant|
       begin
         puts("Migrating #{tenant} tenant")

--- a/spec/adapters/mysql2_adapter_spec.rb
+++ b/spec/adapters/mysql2_adapter_spec.rb
@@ -44,6 +44,7 @@ describe Apartment::Adapters::Mysql2Adapter, database: :mysql do
       before { Apartment.use_schemas = false }
 
       it_should_behave_like "a generic apartment adapter"
+      it_should_behave_like "a generic apartment adapter able to handle custom configuration"
       it_should_behave_like "a connection based apartment adapter"
     end
   end

--- a/spec/adapters/postgresql_adapter_spec.rb
+++ b/spec/adapters/postgresql_adapter_spec.rb
@@ -54,6 +54,7 @@ describe Apartment::Adapters::PostgresqlAdapter, database: :postgresql do
       let(:default_tenant) { subject.switch { ActiveRecord::Base.connection.current_database } }
 
       it_should_behave_like "a generic apartment adapter"
+      it_should_behave_like "a generic apartment adapter able to handle custom configuration"
       it_should_behave_like "a connection based apartment adapter"
     end
   end

--- a/spec/examples/generic_adapter_custom_configuration_example.rb
+++ b/spec/examples/generic_adapter_custom_configuration_example.rb
@@ -1,0 +1,90 @@
+require 'spec_helper'
+
+shared_examples_for "a generic apartment adapter able to handle custom configuration" do
+
+  let(:custom_tenant_name) { 'test_tenantwwww' }
+  let(:db) { |example| example.metadata[:database]}
+  let(:custom_tenant_names) do
+    {
+      custom_tenant_name => get_custom_db_conf
+    }
+  end
+
+  before do
+    Apartment.tenant_names = custom_tenant_names
+  end
+
+  context "database key taken from specific config" do
+
+    let(:expected_args) { get_custom_db_conf }
+
+    describe "#create" do
+      it "should establish_connection with the separate connection with expected args" do
+        expect(Apartment::Adapters::AbstractAdapter::SeparateDbConnectionHandler).to receive(:establish_connection).with(expected_args).and_call_original
+
+        # because we dont have another server to connect to it errors
+        # what matters is establish_connection receives proper args
+        expect { subject.create(custom_tenant_name) }.to raise_error(Apartment::TenantExists)
+      end
+    end
+
+    describe "#drop" do
+      it "should establish_connection with the separate connection with expected args" do
+        expect(Apartment::Adapters::AbstractAdapter::SeparateDbConnectionHandler).to receive(:establish_connection).with(expected_args).and_call_original
+
+        # because we dont have another server to connect to it errors
+        # what matters is establish_connection receives proper args
+        expect { subject.drop(custom_tenant_name) }.to raise_error(Apartment::TenantNotFound)
+      end
+    end
+  end
+
+  context "database key from tenant name" do
+
+    let(:expected_args) {
+      get_custom_db_conf.tap {|args| args.delete(:database) }
+    }
+
+    describe "#switch!" do
+
+      it "should connect to new db" do
+        expect(Apartment).to receive(:establish_connection) do |args|
+          db_name = args.delete(:database)
+
+          expect(args).to eq expected_args
+          expect(db_name).to match custom_tenant_name
+
+          # we only need to check args, then we short circuit
+          # in order to avoid the mess due to the `establish_connection` override
+          raise ActiveRecord::ActiveRecordError
+        end
+
+        expect { subject.switch!(custom_tenant_name) }.to raise_error(Apartment::TenantNotFound)
+      end
+    end
+  end
+
+  def specific_connection
+    {
+      postgresql: {
+        adapter:  'postgresql',
+        database: 'override_database',
+        password: 'override_password',
+        username: 'overridepostgres'
+      },
+      mysql: {
+        adapter:  'mysql2',
+        database: 'override_database',
+        username: 'root'
+      },
+      sqlite: {
+        adapter:  'sqlite3',
+        database: 'override_database'
+      }
+    }
+  end
+
+  def get_custom_db_conf
+    specific_connection[db.to_sym].with_indifferent_access
+  end
+end

--- a/spec/integration/apartment_rake_integration_spec.rb
+++ b/spec/integration/apartment_rake_integration_spec.rb
@@ -33,7 +33,7 @@ describe "apartment rake tasks", database: :postgresql do
 
     let(:x){ 1 + rand(5) }    # random number of dbs to create
     let(:db_names){ x.times.map{ Apartment::Test.next_db } }
-    let!(:company_count){ Company.count + db_names.length }
+    let!(:company_count){ db_names.length }
 
     before do
       db_names.collect do |db_name|

--- a/spec/support/apartment_helpers.rb
+++ b/spec/support/apartment_helpers.rb
@@ -15,6 +15,12 @@ module Apartment
       "db%d" % @x += 1
     end
 
+    def reset_table_names
+      Apartment.excluded_models.each do |model|
+        model.constantize.reset_table_name
+      end
+    end
+
     def drop_schema(schema)
       ActiveRecord::Base.connection.execute("DROP SCHEMA IF EXISTS #{schema} CASCADE") rescue true
     end

--- a/spec/support/setup.rb
+++ b/spec/support/setup.rb
@@ -22,6 +22,7 @@ module Apartment
             # before
             Apartment::Tenant.reload!(config)
             ActiveRecord::Base.establish_connection config
+            Apartment::Test.reset_table_names
 
             example.run
 
@@ -34,9 +35,8 @@ module Apartment
 
               Apartment.connection_class.remove_connection(klass)
               klass.clear_all_connections!
-              klass.reset_table_name
             end
-
+            Apartment::Test.reset_table_names
             Apartment.reset
             Apartment::Tenant.reload!
           end


### PR DESCRIPTION
fix #264 #269 #270

It provides custom configuration for tenants which enable custom connection configuration per tenant, particularly necessary whenever tenants must live in a database on a different server than the main one.

`tenant_names` is the interface: instead of passing an array of strings, a hash is expected for custom configuration. It must follow the pattern:

    config.tenant_names = {
     "tenant_name" => custom_configuration_hash
    }

`templates/apartment.rb` has been updated with details

I've made tests with live dbs on postgresql and mysql / no jruby tests