### PR TITLE
Use the block form of `switch` in the generic elevator

### DIFF
--- a/lib/apartment/elevators/generic.rb
+++ b/lib/apartment/elevators/generic.rb
@@ -18,9 +18,11 @@ module Apartment
 
         database = @processor.call(request)
 
-        Apartment::Tenant.switch! database if database
-
-        @app.call(env)
+        if database
+          Apartment::Tenant.switch(database) { @app.call(env) }
+        else
+          @app.call(env)
+        end
       end
 
       def parse_database_name(request)

--- a/spec/unit/elevators/domain_spec.rb
+++ b/spec/unit/elevators/domain_spec.rb
@@ -24,7 +24,7 @@ describe Apartment::Elevators::Domain do
 
   describe "#call" do
     it "switches to the proper tenant" do
-      Apartment::Tenant.should_receive(:switch!).with('example')
+      Apartment::Tenant.should_receive(:switch).with('example')
 
       elevator.call('HTTP_HOST' => 'www.example.com')
     end

--- a/spec/unit/elevators/generic_spec.rb
+++ b/spec/unit/elevators/generic_spec.rb
@@ -15,7 +15,7 @@ describe Apartment::Elevators::Generic do
     it "calls the processor if given" do
       elevator = described_class.new(Proc.new{}, Proc.new{'tenant1'})
 
-      Apartment::Tenant.should_receive(:switch!).with('tenant1')
+      Apartment::Tenant.should_receive(:switch).with('tenant1')
 
       elevator.call('HTTP_HOST' => 'foo.bar.com')
     end
@@ -29,7 +29,24 @@ describe Apartment::Elevators::Generic do
     it "switches to the parsed db_name" do
       elevator = MyElevator.new(Proc.new{})
 
-      Apartment::Tenant.should_receive(:switch!).with('tenant2')
+      Apartment::Tenant.should_receive(:switch).with('tenant2')
+
+      elevator.call('HTTP_HOST' => 'foo.bar.com')
+    end
+
+    it "calls the block implementation of `switch`" do
+      elevator = MyElevator.new(Proc.new{}, Proc.new{'tenant2'})
+
+      Apartment::Tenant.should_receive(:switch).with('tenant2').and_yield
+      elevator.call('HTTP_HOST' => 'foo.bar.com')
+    end
+
+    it "does not call `switch` if no database given" do
+      app = Proc.new{}
+      elevator = MyElevator.new(app, Proc.new{})
+
+      Apartment::Tenant.should_not_receive(:switch)
+      app.should_receive :call
 
       elevator.call('HTTP_HOST' => 'foo.bar.com')
     end

--- a/spec/unit/elevators/host_hash_spec.rb
+++ b/spec/unit/elevators/host_hash_spec.rb
@@ -24,7 +24,7 @@ describe Apartment::Elevators::HostHash do
 
   describe "#call" do
     it "switches to the proper tenant" do
-      Apartment::Tenant.should_receive(:switch!).with('example_tenant')
+      Apartment::Tenant.should_receive(:switch).with('example_tenant')
 
       elevator.call('HTTP_HOST' => 'example.com')
     end

--- a/spec/unit/elevators/subdomain_spec.rb
+++ b/spec/unit/elevators/subdomain_spec.rb
@@ -39,14 +39,14 @@ describe Apartment::Elevators::Subdomain do
 
   describe "#call" do
     it "switches to the proper tenant" do
-      Apartment::Tenant.should_receive(:switch!).with('tenant1')
+      Apartment::Tenant.should_receive(:switch).with('tenant1')
       elevator.call('HTTP_HOST' => 'tenant1.example.com')
     end
 
     it "ignores excluded subdomains" do
       described_class.excluded_subdomains = %w{foo}
 
-      Apartment::Tenant.should_not_receive(:switch!)
+      Apartment::Tenant.should_not_receive(:switch)
 
       elevator.call('HTTP_HOST' => 'foo.bar.com')
 


### PR DESCRIPTION
Using `switch` and passing a block ensures that an unintended tenant does not remain selected if an error occurs (which is a potential security hole). Fixes #133, #134.
