### PR TITLE
Exclude row_security from dumps.

### DIFF
--- a/lib/apartment/adapters/postgresql_adapter.rb
+++ b/lib/apartment/adapters/postgresql_adapter.rb
@@ -94,7 +94,8 @@ module Apartment
 
       PSQL_DUMP_BLACKLISTED_STATEMENTS= [
         /SET search_path/i,   # overridden later
-        /SET lock_timeout/i   # new in postgresql 9.3
+        /SET lock_timeout/i,  # new in postgresql 9.3
+        /SET row_security/i   # new in postgresql 9.5
       ]
 
       def import_database_schema


### PR DESCRIPTION
This burned us at heroku just now, as they upgraded their pg_\* utilities to 9.5 lately and the 9.4 database barfs on the `row_security` setting.

Not sure how to usefully rspec it, but this clever patch unstuck us.
