### PR TITLE
Change silence_stream to silence_warnings

### DIFF
--- a/lib/apartment/adapters/abstract_adapter.rb
+++ b/lib/apartment/adapters/abstract_adapter.rb
@@ -140,7 +140,7 @@ module Apartment
       #
       def seed_data
         # Don't log the output of seeding the db
-        silence_stream(STDOUT){ load_or_abort(Apartment.seed_data_file) } if Apartment.seed_data_file
+        silence_warnings{ load_or_abort(Apartment.seed_data_file) } if Apartment.seed_data_file
       end
       alias_method :seed, :seed_data
 

--- a/spec/support/apartment_helpers.rb
+++ b/spec/support/apartment_helpers.rb
@@ -34,7 +34,7 @@ module Apartment
     def load_schema(version = 3)
       file = File.expand_path("../../schemas/v#{version}.rb", __FILE__)
 
-      silence_stream(STDOUT){ load(file) }
+      silence_warnings{ load(file) }
     end
 
     def migrate


### PR DESCRIPTION
Ruby 2.3.0
Rails 5.0.0.beta2
Apartment 1.0.2

When enabling seed_after_create, running the db:seed task results in an error due to the deprecated silence_stream method. This PR removes silence_stream and replaces it with silence_warning.