### PR TITLE
Update README.md to include the GRANT usage command to db_enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,8 @@ namespace :db do
     ActiveRecord::Base.connection.execute 'CREATE EXTENSION IF NOT EXISTS HSTORE SCHEMA shared_extensions;'
     # Enable UUID-OSSP
     ActiveRecord::Base.connection.execute 'CREATE EXTENSION IF NOT EXISTS "uuid-ossp" SCHEMA shared_extensions;'
+    # Grant usage to public
+    ActiveRecord::Base.connection.execute 'GRANT usage ON SCHEMA shared_extensions to public;'
   end
 end
 


### PR DESCRIPTION
The db_enhancements rake task is great, but the GRANT usage command is important to ensuring that the shared_extensions schema is available. Without this, the extensions created in this space will not be available in tenant schemas.
