### PR TITLE
Add callbacks on #create and #switch!

### DIFF
--- a/lib/apartment/tenant.rb
+++ b/lib/apartment/tenant.rb
@@ -9,7 +9,7 @@ module Apartment
     extend self
     extend Forwardable
 
-    def_delegators :adapter, :create, :drop, :switch, :switch!, :current, :each, :reset, :seed, :current_tenant, :default_tenant
+    def_delegators :adapter, :create, :drop, :switch, :switch!, :current, :each, :reset, :set_callback, :seed, :current_tenant, :default_tenant
 
     attr_writer :config
 


### PR DESCRIPTION
One additional use case we have for multitenant applications is being able to switch additional connections to external resources (say, a search index connection or a storage bucket). We're currently triggering this logic through some hooks in the controller and/or job, but pushing it down into apartment would give us more confidence that everything is getting appropriately switched.