### PR TITLE
Use mime-types 2.99 when testing with Ruby 1.9

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,3 +7,5 @@ gem 'rails',        '>= 3.1.2'
 group :local do
   gem 'pry'
 end
+
+gem 'mime-types', '~> 2.99', platforms: :ruby_19

--- a/gemfiles/rails_4_0.gemfile
+++ b/gemfiles/rails_4_0.gemfile
@@ -8,4 +8,6 @@ group :local do
   gem "pry"
 end
 
+gem 'mime-types', '~> 2.99', platforms: :ruby_19
+
 gemspec :path => "../"

--- a/gemfiles/rails_4_1.gemfile
+++ b/gemfiles/rails_4_1.gemfile
@@ -8,4 +8,6 @@ group :local do
   gem "pry"
 end
 
+gem 'mime-types', '~> 2.99', platforms: :ruby_19
+
 gemspec :path => "../"

--- a/gemfiles/rails_4_2.gemfile
+++ b/gemfiles/rails_4_2.gemfile
@@ -8,4 +8,6 @@ group :local do
   gem "pry"
 end
 
+gem 'mime-types', '~> 2.99', platforms: :ruby_19
+
 gemspec :path => "../"


### PR DESCRIPTION
mime-types 3.0 is only compatible with Ruby 2.0+.