### PR TITLE
Mysql2 Adapter doesn't escape tenant during drop

### DIFF
--- a/lib/apartment/adapters/abstract_adapter.rb
+++ b/lib/apartment/adapters/abstract_adapter.rb
@@ -152,7 +152,7 @@ module Apartment
 
       def drop_command(conn, tenant)
         # connection.drop_database   note that drop_database will not throw an exception, so manually execute
-        conn.execute("DROP DATABASE #{environmentify(tenant)}")
+        conn.execute("DROP DATABASE `#{environmentify(tenant)}`")
       end
 
       class SeparateDbConnectionHandler < ::ActiveRecord::Base


### PR DESCRIPTION
#131

Even if database name is a Numbers, this SQL runs.
