### PR TITLE
Rails 5.0 support - ar_internal_metadata cloning in pg_adapter

### DIFF
--- a/lib/apartment/adapters/postgresql_adapter.rb
+++ b/lib/apartment/adapters/postgresql_adapter.rb
@@ -140,7 +140,7 @@ module Apartment
       #   @return {String} raw SQL contaning inserts with data from schema_migrations
       #
       def pg_dump_schema_migrations_data
-        with_pg_env { `pg_dump -a --inserts -t schema_migrations -n #{default_tenant} #{dbname}` }
+        with_pg_env { `pg_dump -a --inserts -t schema_migrations -t ar_internal_metadata -n #{default_tenant} #{dbname}` }
       end
 
       # Temporary set Postgresql related environment variables if there are in @config


### PR DESCRIPTION
Trying to make tests pass for Rails 5.0 by applying a fix building on top of "Hidekazu Tanaka" PR.

This fix is to make `postgresql_adapter` recognize and clone the new Rails5 table `ar_internal_metadata` upon schema cloning. Check errors in https://travis-ci.org/influitive/apartment/builds/142076784