### PR TITLE
Skip initialization of Apartment during assets:clean

### DIFF
--- a/lib/apartment/railtie.rb
+++ b/lib/apartment/railtie.rb
@@ -28,7 +28,7 @@ module Apartment
     #   See the middleware/console declarations below to help with this. Hope to fix that soon.
     #
     config.to_prepare do
-      Apartment::Tenant.init unless ARGV.include? 'assets:precompile'
+      Apartment::Tenant.init unless ARGV.any? { |arg| arg =~ /\Aassets:(?:precompile|clean)\z/ }
     end
 
     #


### PR DESCRIPTION
This changes skipping the initialization logic to exclude initializing
of `assets:clean` and `assets:precompile`.

This is an issue occurring when deploying to heroku where apartment
attempts to connect to the database when it is not available and causes
an error to occur.

Fixes #346