### PR TITLE
Fix for AbstractAdapter's DB name escaping in drop_command

### DIFF
--- a/lib/apartment/adapters/abstract_adapter.rb
+++ b/lib/apartment/adapters/abstract_adapter.rb
@@ -159,7 +159,7 @@ module Apartment
 
       def drop_command(conn, tenant)
         # connection.drop_database   note that drop_database will not throw an exception, so manually execute
-        conn.execute("DROP DATABASE #{environmentify(tenant)}")
+        conn.execute("DROP DATABASE #{conn.quote_table_name(environmentify(tenant))}")
       end
 
       #   Create the tenant


### PR DESCRIPTION
fixes #131 and usurps #322