### PR TITLE
Allowing to exclude subdomains by a regular expression

### DIFF
--- a/lib/apartment/elevators/subdomain.rb
+++ b/lib/apartment/elevators/subdomain.rb
@@ -19,13 +19,23 @@ module Apartment
 
         # If the domain acquired is set to be excluded, set the tenant to whatever is currently
         # next in line in the schema search path.
-        tenant = if self.class.excluded_subdomains.include?(request_subdomain)
+        tenant = if excluded_subdomain?(request_subdomain)
           nil
         else
           request_subdomain
         end
 
         tenant.presence
+      end
+
+      def excluded_subdomain?(subdomain)
+        self.class.excluded_subdomains.any? do |excluded_subdomain|
+          if excluded_subdomain.is_a? Regexp
+            subdomain =~ excluded_subdomain
+          else
+            subdomain == excluded_subdomain
+          end
+        end
       end
 
     protected

--- a/spec/unit/elevators/subdomain_spec.rb
+++ b/spec/unit/elevators/subdomain_spec.rb
@@ -53,4 +53,28 @@ describe Apartment::Elevators::Subdomain do
       described_class.excluded_subdomains = nil
     end
   end
+
+  describe "#excluded_subdomain?" do
+    it "must ignore any item of the list" do
+      described_class.excluded_subdomains = %w{foo bar cereal}
+
+      expect(elevator.excluded_subdomain?("foo")).to eq(true)
+      expect(elevator.excluded_subdomain?("bar")).to eq(true)
+      expect(elevator.excluded_subdomain?("cereal")).to eq(true)
+      expect(elevator.excluded_subdomain?("flakes")).to eq(false)
+
+      described_class.excluded_subdomains = nil
+    end
+
+    it "must ignore regexp's on the list that match" do
+      described_class.excluded_subdomains = [/foo/, /bar/, /cereal-\d+/]
+
+      expect(elevator.excluded_subdomain?("food")).to eq(true)
+      expect(elevator.excluded_subdomain?("bareatric")).to eq(true)
+      expect(elevator.excluded_subdomain?("cereal")).to eq(false)
+      expect(elevator.excluded_subdomain?("cereal-1985")).to eq(true)
+
+      described_class.excluded_subdomains = nil
+    end
+  end
 end


### PR DESCRIPTION
I was with this problem, there is a set of subdomains that start with "staging-pr-" then a number and I couldn't do nothing besides generating a huge array from "staging-pr-1" to "staging-pr-9999", and even with this, when I get more then 9999 pull requests on my app, it would stop to work.

So, I implemented to match the excluded subdomain if it is a regexp. The way I made you can even mix them with strings.

Thank you!