### PR TITLE
Don't retain connection used during gem initialisation

### DIFF
--- a/lib/apartment/railtie.rb
+++ b/lib/apartment/railtie.rb
@@ -28,7 +28,11 @@ module Apartment
     #   See the middleware/console declarations below to help with this. Hope to fix that soon.
     #
     config.to_prepare do
-      Apartment::Tenant.init unless ARGV.any? { |arg| arg =~ /\Aassets:(?:precompile|clean)\z/ }
+      unless ARGV.any? { |arg| arg =~ /\Aassets:(?:precompile|clean)\z/ }
+        Apartment.connection_class.connection_pool.with_connection do
+          Apartment::Tenant.init
+        end
+      end
     end
 
     #

--- a/spec/examples/generic_adapter_examples.rb
+++ b/spec/examples/generic_adapter_examples.rb
@@ -8,6 +8,25 @@ shared_examples_for "a generic apartment adapter" do
     Apartment.append_environment = false
   }
 
+  describe "#init" do
+    it "should not retain a connection after railtie" do
+      # this test should work on rails >= 4, the connection pool code is
+      # completely different for 3.2 so we'd have to have a messy conditional..
+      unless Rails::VERSION::MAJOR < 4
+        ActiveRecord::Base.connection_pool.disconnect!
+
+        Apartment::Railtie.config.to_prepare_blocks.map(&:call)
+
+        num_available_connections = Apartment.connection_class.connection_pool
+          .instance_variable_get(:@available)
+          .instance_variable_get(:@queue)
+          .size
+
+        expect(num_available_connections).to eq(1)
+      end
+    end
+  end
+
   #
   #   Creates happen already in our before_filter
   #


### PR DESCRIPTION
When the gem is initialised and a schema adapter is being used, the
adapter will initialise the schema_search_path which involves
touching the database, and thus checking out a connection for the
current thread. For threaded web servers, it is not expected that
the main thread has a database connection, so you typically set the
connection pool size equal to the number of web server threads.

This patch checks the connection back in to the pool after init so
that a web server thread can pick it up and use it.

Fixes #321 