### PR TITLE
Accept DB config

### DIFF
--- a/lib/apartment/adapters/abstract_adapter.rb
+++ b/lib/apartment/adapters/abstract_adapter.rb
@@ -175,7 +175,7 @@ module Apartment
       end
 
       def create_tenant_command(conn, tenant)
-        conn.create_database(environmentify(tenant))
+        conn.create_database(environmentify(tenant), @config)
       end
 
       #   Connect to new tenant


### PR DESCRIPTION
This PR enables apartment to accept DB configurations while creating a new DB (=Tenant).
Ideally, `#create_tenant` should behave same as `rake db:create` task.

**PostgreSQL**

You can specify `:owner`, `:template`, `:encoding`, `:collation`, `:ctype`, `:tablespace`, and `:connection_limit` on your database.yml.

See: [create\_database \(ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaStatements\) \- APIdock](http://apidock.com/rails/ActiveRecord/ConnectionAdapters/PostgreSQL/SchemaStatements/create_database)

**MySQL**

You can specify `:charset` and `:collation` on your database.yml.

See: [create\_database \(ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter\) \- APIdock](http://apidock.com/rails/ActiveRecord/ConnectionAdapters/AbstractMysqlAdapter/create_database)