### PR TITLE
Support parallel migration task

### DIFF
--- a/apartment.gemspec
+++ b/apartment.gemspec
@@ -37,6 +37,7 @@ Gem::Specification.new do |s|
   # must be >= 3.1.2 due to bug in prepared_statements
   s.add_dependency 'activerecord',    '>= 3.1.2', '< 6.0'
   s.add_dependency 'rack',            '>= 1.3.6'
+  s.add_dependency 'parallel',        '>= 1.10'
 
   s.add_development_dependency 'appraisal'
   s.add_development_dependency 'rake',         '~> 0.9'

--- a/lib/apartment.rb
+++ b/lib/apartment.rb
@@ -2,6 +2,7 @@ require 'apartment/railtie' if defined?(Rails)
 require 'active_support/core_ext/object/blank'
 require 'forwardable'
 require 'active_record'
+require 'parallel'
 require 'apartment/tenant'
 require 'apartment/deprecation'
 

--- a/lib/tasks/apartment.rake
+++ b/lib/tasks/apartment.rake
@@ -27,6 +27,23 @@ apartment_namespace = namespace :apartment do
     end
   end
 
+  namespace :migrate do
+    desc 'Migrate all tenants in parallel'
+    task :parallel, [:in_processes] do |task, args|
+      args.with_defaults(in_processes: 2)
+      warn_if_tenants_empty
+
+      Parallel.each(tenants, in_processes: args.in_processes) do |tenant_name|
+        begin
+          puts("Migrating #{tenant_name} tenant")
+          Apartment::Migrator.migrate tenant_name
+        rescue Apartment::TenantNotFound => e
+          puts e.message
+        end
+      end
+    end
+  end
+
   desc "Seed all tenants"
   task :seed do
     warn_if_tenants_empty

--- a/spec/tasks/apartment_rake_spec.rb
+++ b/spec/tasks/apartment_rake_spec.rb
@@ -10,6 +10,7 @@ describe "apartment rake tasks" do
     load 'tasks/apartment.rake'
     # stub out rails tasks
     Rake::Task.define_task('db:migrate')
+    Rake::Task.define_task('db:migrate:prallel')
     Rake::Task.define_task('db:seed')
     Rake::Task.define_task('db:rollback')
     Rake::Task.define_task('db:migrate:up')
@@ -45,6 +46,17 @@ describe "apartment rake tasks" do
       it "should migrate public and all multi-tenant dbs" do
         expect(Apartment::Migrator).to receive(:migrate).exactly(tenant_count).times
         @rake['apartment:migrate'].invoke
+      end
+    end
+
+    describe "apartment:migrate:prallel" do
+      before do
+        allow(Apartment::Migrator).to receive(:migrate)   # don't care about this
+      end
+
+      it "should migrate public and all multi-tenant dbs" do
+        expect(Parallel).to receive(:each).with(tenant_names, in_processes: 2)
+        @rake['apartment:migrate:parallel'].invoke
       end
     end
 

--- a/spec/tasks/apartment_rake_spec.rb
+++ b/spec/tasks/apartment_rake_spec.rb
@@ -10,7 +10,7 @@ describe "apartment rake tasks" do
     load 'tasks/apartment.rake'
     # stub out rails tasks
     Rake::Task.define_task('db:migrate')
-    Rake::Task.define_task('db:migrate:prallel')
+    Rake::Task.define_task('db:migrate:parallel')
     Rake::Task.define_task('db:seed')
     Rake::Task.define_task('db:rollback')
     Rake::Task.define_task('db:migrate:up')
@@ -49,7 +49,7 @@ describe "apartment rake tasks" do
       end
     end
 
-    describe "apartment:migrate:prallel" do
+    describe "apartment:migrate:parallel" do
       before do
         allow(Apartment::Migrator).to receive(:migrate)   # don't care about this
       end


### PR DESCRIPTION
Hi :)  This PR is supporting migration in parallel.
#75 was using threads, but this PR migrate processes in parallel.
In my environment, the speed got 66% faster  by running the processes in parallel.

__Hardware infomation__

```
$ system_profiler SPHardwareDataType
Hardware:

    Hardware Overview:

      Model Name: MacBook Pro
      Model Identifier: MacBookPro12,1
      Processor Name: Intel Core i5
      Processor Speed: 2.7 GHz
      Number of Processors: 1
      Total Number of Cores: 2
      L2 Cache (per Core): 256 KB
      L3 Cache: 3 MB
      Memory: 16 GB
      Boot ROM Version: MBP121.0167.B17
      SMC Version (system): 2.28f7
      Serial Number (system): C02SC0R2FVH4
      Hardware UUID: B52BB064-8731-5ED4-B78A-48C843E5792A
```

__Speed__

```
bin/rake db:migrate  46.62s user 5.52s system 55% cpu 1:33.62 total
bin/rake db:migrate  43.95s user 5.27s system 54% cpu 1:29.66 total
bin/rake db:migrate  44.61s user 5.37s system 54% cpu 1:30.93 total

bin/rake db:migrate:parallel  66.93s user 7.66s system 131% cpu 56.568 total
bin/rake db:migrate:parallel  67.48s user 7.82s system 132% cpu 57.008 total
bin/rake db:migrate:parallel  66.37s user 7.91s system 131% cpu 56.533 total
```