### PR TITLE
Added Makara adapter for PostgreSQL

### DIFF
--- a/lib/apartment/adapters/postgresql_makara_adapter.rb
+++ b/lib/apartment/adapters/postgresql_makara_adapter.rb
@@ -1,0 +1,12 @@
+# handle postgresql_makara_adapter adapter as if it were postgresql,
+# only override the adapter_method used for initialization
+require "apartment/adapters/postgresql_adapter"
+
+module Apartment
+  module Tenant
+
+    def self.postgresql_makara_adapter(config)
+      postgresql_adapter(config)
+    end
+  end
+end


### PR DESCRIPTION
Similar to `postgis` adapter, this is a "dummy" adapter that introduces compatibility with [Makara](https://github.com/taskrabbit/makara)'s PostgreSQL adapter.

No tests included because this doesn't add any new functionality, just a named "alias" to prevent the "adapter not compatible" error.