### PR TITLE
Kernel#quietly was deprecated in Rails 4.2

### DIFF
--- a/lib/tasks/apartment.rake
+++ b/lib/tasks/apartment.rake
@@ -7,7 +7,7 @@ apartment_namespace = namespace :apartment do
     tenants.each do |tenant|
       begin
         puts("Creating #{tenant} tenant")
-        quietly { Apartment::Tenant.create(tenant) }
+        Apartment::Tenant.create(tenant)
       rescue Apartment::TenantExists => e
         puts e.message
       end


### PR DESCRIPTION
The gem rake task doesn't work for me in Rails 5. Kernel#quietly was deprecated without replacement.
More info:
  - http://guides.rubyonrails.org/4_2_release_notes.html
  - https://github.com/rails/rails/pull/13392