### PR TITLE
Add possibility to check for tenant existance

### DIFF
--- a/lib/apartment/adapters/abstract_adapter.rb
+++ b/lib/apartment/adapters/abstract_adapter.rb
@@ -123,10 +123,7 @@ module Apartment
       #   Checks whether a tenant exists or not
       #
       def exist?(tenant)
-        # Needs to get implemented by each adapter
-        with_neutral_connection(tenant) do |conn|
-          !!exist_command(conn, tenant)
-        end
+        false
       end
 
     protected

--- a/lib/apartment/adapters/abstract_adapter.rb
+++ b/lib/apartment/adapters/abstract_adapter.rb
@@ -125,7 +125,7 @@ module Apartment
       def exist?(tenant)
         # Needs to get implemented by each adapter
         with_neutral_connection(tenant) do |conn|
-          exist_command(conn, tenant)
+          !!exist_command(conn, tenant)
         end
       end
 

--- a/lib/apartment/adapters/abstract_adapter.rb
+++ b/lib/apartment/adapters/abstract_adapter.rb
@@ -120,6 +120,15 @@ module Apartment
       end
       alias_method :seed, :seed_data
 
+      #   Checks whether a tenant exists or not
+      #
+      def exist?(tenant)
+        # Needs to get implemented by each adapter
+        with_neutral_connection(tenant) do |conn|
+          exist_command(conn, tenant)
+        end
+      end
+
     protected
 
       def process_excluded_model(excluded_model)

--- a/lib/apartment/adapters/mysql2_adapter.rb
+++ b/lib/apartment/adapters/mysql2_adapter.rb
@@ -19,12 +19,12 @@ module Apartment
         @default_tenant = config[:database]
       end
 
-    protected
-
-      def exist_command(conn, tenant)
-        result = conn.execute("SELECT 1 AS `exists` FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = #{conn.quote_table_name(environmentify(tenant))}").try(:first)
-        result && result['exists'] == '1'
+      def exist?(tenant)
+        result = Apartment.connection.exec_query("SELECT 1 AS `exists` FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = #{Apartment.connection.quote(environmentify(tenant))}").try(:first)
+        result.present? && result['exists'] == 1
       end
+
+    protected
 
       def rescue_from
         Mysql2::Error
@@ -43,6 +43,11 @@ module Apartment
       #
       def reset
         Apartment.connection.execute "use `#{default_tenant}`"
+      end
+
+      def exist?(tenant)
+        result = Apartment.connection.exec_query("SELECT 1 AS `exists` FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = #{Apartment.connection.quote(environmentify(tenant))}").try(:first)
+        result.present? && result['exists'] == 1
       end
 
     protected
@@ -72,10 +77,6 @@ module Apartment
         true
       end
 
-      def exist_command(conn, tenant)
-        result = conn.execute("SELECT 1 AS `exists` FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = #{conn.quote_table_name(environmentify(tenant))}").try(:first)
-        result && result['exists'] == '1'
-      end
     end
   end
 end

--- a/lib/apartment/adapters/mysql2_adapter.rb
+++ b/lib/apartment/adapters/mysql2_adapter.rb
@@ -21,6 +21,11 @@ module Apartment
 
     protected
 
+      def exist_command(conn, tenant)
+        result = conn.execute("SELECT 1 AS `exists` FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = #{conn.quote_table_name(environmentify(tenant))}").try(:first)
+        result && result['exists'] == '1'
+      end
+
       def rescue_from
         Mysql2::Error
       end
@@ -65,6 +70,11 @@ module Apartment
 
       def reset_on_connection_exception?
         true
+      end
+
+      def exist_command(conn, tenant)
+        result = conn.execute("SELECT 1 AS `exists` FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = #{conn.quote_table_name(environmentify(tenant))}").try(:first)
+        result && result['exists'] == '1'
       end
     end
   end

--- a/lib/apartment/adapters/postgresql_adapter.rb
+++ b/lib/apartment/adapters/postgresql_adapter.rb
@@ -15,6 +15,13 @@ module Apartment
     # Default adapter when not using Postgresql Schemas
     class PostgresqlAdapter < AbstractAdapter
 
+    protected
+
+      def exist_command(conn, tenant)
+        result = conn.execute("SELECT EXISTS(SELECT 1 FROM pg_database WHERE datname = '#{environmentify(tenant)}')").try(:first)
+        result && result['exists']
+      end
+
     private
 
       def rescue_from
@@ -57,6 +64,12 @@ module Apartment
 
       def drop_command(conn, tenant)
         conn.execute(%{DROP SCHEMA "#{tenant}" CASCADE})
+      end
+
+      def exist_command(conn, tenant)
+        # Needs to get implemented by each adapter
+        result = conn.execute("SELECT EXISTS(SELECT 1 FROM pg_namespace WHERE nspname = '#{environmentify(tenant)}')").try(:first)
+        result && result['exists']
       end
 
       #   Set schema search path to new schema

--- a/lib/apartment/adapters/sqlite3_adapter.rb
+++ b/lib/apartment/adapters/sqlite3_adapter.rb
@@ -26,6 +26,10 @@ module Apartment
         File.basename(Apartment.connection.instance_variable_get(:@config)[:database], '.sqlite3')
       end
 
+      def exist?(tenant)
+        File.exist?(database_file(tenant))
+      end
+
     protected
 
       def connect_to_new(tenant)

--- a/lib/apartment/tenant.rb
+++ b/lib/apartment/tenant.rb
@@ -8,7 +8,7 @@ module Apartment
     extend self
     extend Forwardable
 
-    def_delegators :adapter, :create, :drop, :switch, :switch!, :current, :each, :reset, :set_callback, :seed, :current_tenant, :default_tenant
+    def_delegators :adapter, :create, :drop, :switch, :switch!, :current, :each, :reset, :set_callback, :seed, :current_tenant, :default_tenant, :exist?
 
     attr_writer :config
 

--- a/spec/examples/generic_adapter_examples.rb
+++ b/spec/examples/generic_adapter_examples.rb
@@ -144,4 +144,16 @@ shared_examples_for "a generic apartment adapter" do
       expect(result).to eq([db2])
     end
   end
+
+  describe "#exist" do
+    it 'should return true if tenant exists' do
+      subject.create('resident')
+      expect(subject.exist?('resident')).to be true
+      subject.drop('resident')
+    end
+
+    it 'should return false if tenant does not exists' do
+      expect(subject.exist?('resident')).to be false
+    end
+  end
 end

--- a/spec/support/requirements.rb
+++ b/spec/support/requirements.rb
@@ -22,6 +22,7 @@ module Apartment
           # sometimes we manually drop these schemas in testing, don't care if we can't drop, hence rescue
           subject.drop(db1) rescue true
           subject.drop(db2) rescue true
+          subject.drop('resident') rescue true
         end
       end
 

--- a/spec/tenant_spec.rb
+++ b/spec/tenant_spec.rb
@@ -103,13 +103,6 @@ describe Apartment::Tenant do
         end
       end
 
-      describe "#exist" do
-        it "should check if tenant exist" do
-          expect(subject.exist?(db1)).to be true
-          expect(subject.exist?('blah')).to be false
-        end
-      end
-
       describe "#switch!" do
 
         let(:x){ rand(3) }

--- a/spec/tenant_spec.rb
+++ b/spec/tenant_spec.rb
@@ -103,6 +103,13 @@ describe Apartment::Tenant do
         end
       end
 
+      describe "#exist" do
+        it "should check if tenant exist" do
+          expect(subject.exist?(db1)).to be true
+          expect(subject.exist?('blah')).to be false
+        end
+      end
+
       describe "#switch!" do
 
         let(:x){ rand(3) }


### PR DESCRIPTION
I added a new method called ```exist?``` to make it easy for checking if a tenant was already created. I needed this to check for customers tenants.

So then can do stuff like:

```ruby
Apartment::Tenant.create('resident') unless Apartment::Tenant.exist?('resident')
```

I think it's cleaner like this than catching the exception.

I wasn't sure about the MySQL adapter so I duplicated the method. 😅 
