### PR TITLE
Fix create for libpq 9.6 and older db

### DIFF
--- a/lib/apartment/adapters/postgresql_adapter.rb
+++ b/lib/apartment/adapters/postgresql_adapter.rb
@@ -107,8 +107,8 @@ module Apartment
 
       PSQL_DUMP_BLACKLISTED_STATEMENTS= [
         /SET search_path/i,   # overridden later
-        /SET lock_timeout/i   # new in postgresql 9.3
-        /SET idle_in_transaction_session_timeout/i   # new in postgresql 9.6
+        /SET lock_timeout/i,   # new in postgresql 9.3
+        /SET idle_in_transaction_session_timeout/i,   # new in postgresql 9.6
       ]
 
       def import_database_schema

--- a/lib/apartment/adapters/postgresql_adapter.rb
+++ b/lib/apartment/adapters/postgresql_adapter.rb
@@ -108,6 +108,7 @@ module Apartment
       PSQL_DUMP_BLACKLISTED_STATEMENTS= [
         /SET search_path/i,   # overridden later
         /SET lock_timeout/i   # new in postgresql 9.3
+        /SET idle_in_transaction_session_timeout/i   # new in postgresql 9.6
       ]
 
       def import_database_schema


### PR DESCRIPTION
When Postgres library (libpq) 9.6 is installed on the server, `pg_dump` adds an SQL command to SET `idle_in_transaction_session_timeout`, which is new to 9.6, so it fails when running against older versions of the Postgres database.

I've added the parameter to the blacklist.

Is this acceptable?