### PR TITLE
add parallel task support for migrate, rollback, seed, up, down

### DIFF
--- a/apartment.gemspec
+++ b/apartment.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'activerecord',    '>= 3.1.2', '< 6.0'
   s.add_dependency 'rack',            '>= 1.3.6'
   s.add_dependency 'public_suffix',   '~> 2.0.5'
+  s.add_dependency 'parallel',        '>= 1.10'
 
   s.add_development_dependency 'appraisal'
   s.add_development_dependency 'rake',         '~> 0.9'

--- a/lib/apartment.rb
+++ b/lib/apartment.rb
@@ -1,6 +1,7 @@
 require 'apartment/railtie' if defined?(Rails)
 require 'active_support/core_ext/object/blank'
 require 'forwardable'
+require 'parallel'
 require 'active_record'
 require 'apartment/tenant'
 
@@ -10,8 +11,8 @@ module Apartment
 
     extend Forwardable
 
-    ACCESSOR_METHODS  = [:use_schemas, :use_sql, :seed_after_create, :prepend_environment, :append_environment, :with_multi_server_setup ]
-    WRITER_METHODS    = [:tenant_names, :database_schema_file, :excluded_models, :default_schema, :persistent_schemas, :connection_class, :tld_length, :db_migrate_tenants, :seed_data_file]
+    ACCESSOR_METHODS  = [:use_schemas, :use_sql, :seed_after_create, :prepend_environment, :append_environment, :with_multi_server_setup, :use_parallel_tenant_task ]
+    WRITER_METHODS    = [:tenant_names, :database_schema_file, :excluded_models, :default_schema, :persistent_schemas, :connection_class, :tld_length, :db_migrate_tenants, :seed_data_file, :num_parallel_threads]
 
     attr_accessor(*ACCESSOR_METHODS)
     attr_writer(*WRITER_METHODS)
@@ -72,6 +73,12 @@ module Apartment
       return @seed_data_file if defined?(@seed_data_file)
 
       @seed_data_file = "#{Rails.root}/db/seeds.rb"
+    end
+
+    def num_parallel_threads
+      return @num_parallel_threads if defined?(@num_parallel_threads)
+
+      @num_parallel_threads = [1,ActiveRecord::Base.connection_pool.size - 2].max
     end
 
     # Reset all the config for Apartment

--- a/lib/apartment.rb
+++ b/lib/apartment.rb
@@ -12,7 +12,7 @@ module Apartment
     extend Forwardable
 
     ACCESSOR_METHODS  = [:use_schemas, :use_sql, :seed_after_create, :prepend_environment, :append_environment, :with_multi_server_setup, :use_parallel_tenant_task ]
-    WRITER_METHODS    = [:tenant_names, :database_schema_file, :excluded_models, :default_schema, :persistent_schemas, :connection_class, :tld_length, :db_migrate_tenants, :seed_data_file, :num_parallel_threads]
+    WRITER_METHODS    = [:tenant_names, :database_schema_file, :excluded_models, :default_schema, :persistent_schemas, :connection_class, :tld_length, :db_migrate_tenants, :seed_data_file, :num_parallel_in_processes]
 
     attr_accessor(*ACCESSOR_METHODS)
     attr_writer(*WRITER_METHODS)
@@ -75,10 +75,10 @@ module Apartment
       @seed_data_file = "#{Rails.root}/db/seeds.rb"
     end
 
-    def num_parallel_threads
-      return @num_parallel_threads if defined?(@num_parallel_threads)
+    def num_parallel_in_processes
+      return @num_parallel_in_processes if defined?(@num_parallel_in_processes)
 
-      @num_parallel_threads = [1,ActiveRecord::Base.connection_pool.size - 2].max
+      @num_parallel_in_processes = [1,ActiveRecord::Base.connection_pool.size - 2].max
     end
 
     # Reset all the config for Apartment

--- a/lib/tasks/apartment.rake
+++ b/lib/tasks/apartment.rake
@@ -17,7 +17,7 @@ apartment_namespace = namespace :apartment do
   desc "Migrate all tenants"
   task :migrate do
     warn_if_tenants_empty
-    tenants.each do |tenant|
+    parallel_each(tenants) do |tenant|
       begin
         puts("Migrating #{tenant} tenant")
         Apartment::Migrator.migrate tenant
@@ -31,7 +31,7 @@ apartment_namespace = namespace :apartment do
   task :seed do
     warn_if_tenants_empty
 
-    tenants.each do |tenant|
+    parallel_each(tenants) do |tenant|
       begin
         puts("Seeding #{tenant} tenant")
         Apartment::Tenant.switch(tenant) do
@@ -49,7 +49,7 @@ apartment_namespace = namespace :apartment do
 
     step = ENV['STEP'] ? ENV['STEP'].to_i : 1
 
-    tenants.each do |tenant|
+    parallel_each(tenants) do |tenant|
       begin
         puts("Rolling back #{tenant} tenant")
         Apartment::Migrator.rollback tenant, step
@@ -67,7 +67,7 @@ apartment_namespace = namespace :apartment do
       version = ENV['VERSION'] ? ENV['VERSION'].to_i : nil
       raise 'VERSION is required' unless version
 
-      tenants.each do |tenant|
+      parallel_each(tenants) do |tenant|
         begin
           puts("Migrating #{tenant} tenant up")
           Apartment::Migrator.run :up, tenant, version
@@ -84,7 +84,7 @@ apartment_namespace = namespace :apartment do
       version = ENV['VERSION'] ? ENV['VERSION'].to_i : nil
       raise 'VERSION is required' unless version
 
-      tenants.each do |tenant|
+      parallel_each(tenants) do |tenant|
         begin
           puts("Migrating #{tenant} tenant down")
           Apartment::Migrator.run :down, tenant, version
@@ -121,6 +121,18 @@ apartment_namespace = namespace :apartment do
 
         Note that your tenants currently haven't been migrated. You'll need to run `db:migrate` to rectify this.
       WARNING
+    end
+  end
+
+  def parallel_each(tenants)
+    if Apartment.use_parallel_tenant_task
+      Parallel.each(tenants, in_processes: Apartment.num_parallel_threads ) do |tenant_name|
+        yield tenant_name
+      end
+    else
+      tenants.each do |tenant_name|
+        yield tenant_name
+      end
     end
   end
 end

--- a/lib/tasks/apartment.rake
+++ b/lib/tasks/apartment.rake
@@ -17,7 +17,7 @@ apartment_namespace = namespace :apartment do
   desc "Migrate all tenants"
   task :migrate do
     warn_if_tenants_empty
-    parallel_each(tenants) do |tenant|
+    iterate_tenants do |tenant|
       begin
         puts("Migrating #{tenant} tenant")
         Apartment::Migrator.migrate tenant
@@ -31,7 +31,7 @@ apartment_namespace = namespace :apartment do
   task :seed do
     warn_if_tenants_empty
 
-    parallel_each(tenants) do |tenant|
+    iterate_tenants do |tenant|
       begin
         puts("Seeding #{tenant} tenant")
         Apartment::Tenant.switch(tenant) do
@@ -49,7 +49,7 @@ apartment_namespace = namespace :apartment do
 
     step = ENV['STEP'] ? ENV['STEP'].to_i : 1
 
-    parallel_each(tenants) do |tenant|
+    iterate_tenants do |tenant|
       begin
         puts("Rolling back #{tenant} tenant")
         Apartment::Migrator.rollback tenant, step
@@ -67,7 +67,7 @@ apartment_namespace = namespace :apartment do
       version = ENV['VERSION'] ? ENV['VERSION'].to_i : nil
       raise 'VERSION is required' unless version
 
-      parallel_each(tenants) do |tenant|
+      iterate_tenants do |tenant|
         begin
           puts("Migrating #{tenant} tenant up")
           Apartment::Migrator.run :up, tenant, version
@@ -84,7 +84,7 @@ apartment_namespace = namespace :apartment do
       version = ENV['VERSION'] ? ENV['VERSION'].to_i : nil
       raise 'VERSION is required' unless version
 
-      parallel_each(tenants) do |tenant|
+      iterate_tenants do |tenant|
         begin
           puts("Migrating #{tenant} tenant down")
           Apartment::Migrator.run :down, tenant, version
@@ -124,9 +124,9 @@ apartment_namespace = namespace :apartment do
     end
   end
 
-  def parallel_each(tenants)
+  def iterate_tenants
     if Apartment.use_parallel_tenant_task
-      Parallel.each(tenants, in_processes: Apartment.num_parallel_threads ) do |tenant_name|
+      Parallel.each(tenants, in_processes: Apartment.num_parallel_in_processes ) do |tenant_name|
         yield tenant_name
       end
     else

--- a/spec/tasks/apartment_rake_spec.rb
+++ b/spec/tasks/apartment_rake_spec.rb
@@ -51,7 +51,7 @@ describe "apartment rake tasks" do
         Apartment.configure do |config|
           config.use_parallel_tenant_task = true
         end
-        expect(Parallel).to receive(:each).with(tenant_names, in_processes: Apartment.num_parallel_threads)
+        expect(Parallel).to receive(:each).with(tenant_names, in_processes: Apartment.num_parallel_in_processes)
         @rake['apartment:migrate'].invoke
       end
 
@@ -59,7 +59,7 @@ describe "apartment rake tasks" do
         Apartment.configure do |config|
           config.use_parallel_tenant_task = false
         end
-        expect(Parallel).not_to receive(:each).with(tenant_names, in_processes: Apartment.num_parallel_threads)
+        expect(Parallel).not_to receive(:each).with(tenant_names, in_processes: Apartment.num_parallel_in_processes)
         @rake['apartment:migrate'].invoke
       end
     end
@@ -93,7 +93,7 @@ describe "apartment rake tasks" do
           Apartment.configure do |config|
             config.use_parallel_tenant_task = true
           end
-          expect(Parallel).to receive(:each).with(tenant_names, in_processes: Apartment.num_parallel_threads)
+          expect(Parallel).to receive(:each).with(tenant_names, in_processes: Apartment.num_parallel_in_processes)
           @rake['apartment:migrate:up'].invoke
         end
 
@@ -101,7 +101,7 @@ describe "apartment rake tasks" do
           Apartment.configure do |config|
             config.use_parallel_tenant_task = false
           end
-          expect(Parallel).not_to receive(:each).with(tenant_names, in_processes: Apartment.num_parallel_threads)
+          expect(Parallel).not_to receive(:each).with(tenant_names, in_processes: Apartment.num_parallel_in_processes)
           @rake['apartment:migrate:up'].invoke
         end
       end
@@ -136,7 +136,7 @@ describe "apartment rake tasks" do
           Apartment.configure do |config|
             config.use_parallel_tenant_task = true
           end
-          expect(Parallel).to receive(:each).with(tenant_names, in_processes: Apartment.num_parallel_threads)
+          expect(Parallel).to receive(:each).with(tenant_names, in_processes: Apartment.num_parallel_in_processes)
           @rake['apartment:migrate:down'].invoke
         end
 
@@ -144,7 +144,7 @@ describe "apartment rake tasks" do
           Apartment.configure do |config|
             config.use_parallel_tenant_task = false
           end
-          expect(Parallel).not_to receive(:each).with(tenant_names, in_processes: Apartment.num_parallel_threads)
+          expect(Parallel).not_to receive(:each).with(tenant_names, in_processes: Apartment.num_parallel_in_processes)
           @rake['apartment:migrate:down'].invoke
         end
       end
@@ -168,7 +168,7 @@ describe "apartment rake tasks" do
         Apartment.configure do |config|
           config.use_parallel_tenant_task = true
         end
-        expect(Parallel).to receive(:each).with(tenant_names, in_processes: Apartment.num_parallel_threads)
+        expect(Parallel).to receive(:each).with(tenant_names, in_processes: Apartment.num_parallel_in_processes)
         @rake['apartment:rollback'].invoke
       end
 
@@ -176,7 +176,7 @@ describe "apartment rake tasks" do
         Apartment.configure do |config|
           config.use_parallel_tenant_task = false
         end
-        expect(Parallel).not_to receive(:each).with(tenant_names, in_processes: Apartment.num_parallel_threads)
+        expect(Parallel).not_to receive(:each).with(tenant_names, in_processes: Apartment.num_parallel_in_processes)
         @rake['apartment:rollback'].invoke
       end
     end

--- a/spec/tasks/apartment_rake_spec.rb
+++ b/spec/tasks/apartment_rake_spec.rb
@@ -46,6 +46,22 @@ describe "apartment rake tasks" do
         expect(Apartment::Migrator).to receive(:migrate).exactly(tenant_count).times
         @rake['apartment:migrate'].invoke
       end
+
+      it "should invoke Parallel.each when use parallel mode" do
+        Apartment.configure do |config|
+          config.use_parallel_tenant_task = true
+        end
+        expect(Parallel).to receive(:each).with(tenant_names, in_processes: Apartment.num_parallel_threads)
+        @rake['apartment:migrate'].invoke
+      end
+
+      it "should not invoke Parallel.each when it does not use parallel mode" do
+        Apartment.configure do |config|
+          config.use_parallel_tenant_task = false
+        end
+        expect(Parallel).not_to receive(:each).with(tenant_names, in_processes: Apartment.num_parallel_threads)
+        @rake['apartment:migrate'].invoke
+      end
     end
 
     describe "apartment:migrate:up" do
@@ -70,6 +86,22 @@ describe "apartment rake tasks" do
 
         it "migrates up to a specific version" do
           expect(Apartment::Migrator).to receive(:run).with(:up, anything, version.to_i).exactly(tenant_count).times
+          @rake['apartment:migrate:up'].invoke
+        end
+
+        it "should invoke Parallel.each when use parallel mode" do
+          Apartment.configure do |config|
+            config.use_parallel_tenant_task = true
+          end
+          expect(Parallel).to receive(:each).with(tenant_names, in_processes: Apartment.num_parallel_threads)
+          @rake['apartment:migrate:up'].invoke
+        end
+
+        it "should not invoke Parallel.each when it does not use parallel mode" do
+          Apartment.configure do |config|
+            config.use_parallel_tenant_task = false
+          end
+          expect(Parallel).not_to receive(:each).with(tenant_names, in_processes: Apartment.num_parallel_threads)
           @rake['apartment:migrate:up'].invoke
         end
       end
@@ -99,6 +131,22 @@ describe "apartment rake tasks" do
           expect(Apartment::Migrator).to receive(:run).with(:down, anything, version.to_i).exactly(tenant_count).times
           @rake['apartment:migrate:down'].invoke
         end
+
+        it "should invoke Parallel.each when use parallel mode" do
+          Apartment.configure do |config|
+            config.use_parallel_tenant_task = true
+          end
+          expect(Parallel).to receive(:each).with(tenant_names, in_processes: Apartment.num_parallel_threads)
+          @rake['apartment:migrate:down'].invoke
+        end
+
+        it "should not invoke Parallel.each when it does not use parallel mode" do
+          Apartment.configure do |config|
+            config.use_parallel_tenant_task = false
+          end
+          expect(Parallel).not_to receive(:each).with(tenant_names, in_processes: Apartment.num_parallel_threads)
+          @rake['apartment:migrate:down'].invoke
+        end
       end
     end
 
@@ -113,6 +161,22 @@ describe "apartment rake tasks" do
       it "should rollback dbs STEP amt" do
         expect(Apartment::Migrator).to receive(:rollback).with(anything, step.to_i).exactly(tenant_count).times
         ENV['STEP'] = step
+        @rake['apartment:rollback'].invoke
+      end
+
+      it "should invoke Parallel.each when use parallel mode" do
+        Apartment.configure do |config|
+          config.use_parallel_tenant_task = true
+        end
+        expect(Parallel).to receive(:each).with(tenant_names, in_processes: Apartment.num_parallel_threads)
+        @rake['apartment:rollback'].invoke
+      end
+
+      it "should not invoke Parallel.each when it does not use parallel mode" do
+        Apartment.configure do |config|
+          config.use_parallel_tenant_task = false
+        end
+        expect(Parallel).not_to receive(:each).with(tenant_names, in_processes: Apartment.num_parallel_threads)
         @rake['apartment:rollback'].invoke
       end
     end

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -6,6 +6,7 @@ describe Apartment do
 
     let(:excluded_models){ ["Company"] }
     let(:seed_data_file_path){ "#{Rails.root}/db/seeds/import.rb" }
+    let(:num_parallel_threads) { 5 }
 
     def tenant_names_from_array(names)
       names.each_with_object({}) do |tenant, hash|
@@ -48,6 +49,17 @@ describe Apartment do
         config.seed_after_create = true
       end
       expect(Apartment.seed_after_create).to be true
+    end
+
+    it "should set num_parallel_threads" do
+      Apartment.configure do |config|
+        config.num_parallel_threads = num_parallel_threads
+      end
+      expect(Apartment.num_parallel_threads).to eq(num_parallel_threads)
+    end
+
+    it "should have default num_parallel_threads that less than or equal to ActiveRecord::Base.connection_pool.size" do
+      expect(Apartment.num_parallel_threads).to be <= ActiveRecord::Base.connection_pool.size
     end
 
     context "databases" do

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -6,7 +6,7 @@ describe Apartment do
 
     let(:excluded_models){ ["Company"] }
     let(:seed_data_file_path){ "#{Rails.root}/db/seeds/import.rb" }
-    let(:num_parallel_threads) { 5 }
+    let(:num_parallel_in_processes) { 5 }
 
     def tenant_names_from_array(names)
       names.each_with_object({}) do |tenant, hash|
@@ -51,15 +51,15 @@ describe Apartment do
       expect(Apartment.seed_after_create).to be true
     end
 
-    it "should set num_parallel_threads" do
+    it "should set num_parallel_in_processes" do
       Apartment.configure do |config|
-        config.num_parallel_threads = num_parallel_threads
+        config.num_parallel_in_processes = num_parallel_in_processes
       end
-      expect(Apartment.num_parallel_threads).to eq(num_parallel_threads)
+      expect(Apartment.num_parallel_in_processes).to eq(num_parallel_in_processes)
     end
 
-    it "should have default num_parallel_threads that less than or equal to ActiveRecord::Base.connection_pool.size" do
-      expect(Apartment.num_parallel_threads).to be <= ActiveRecord::Base.connection_pool.size
+    it "should have default num_parallel_in_processes that less than or equal to ActiveRecord::Base.connection_pool.size" do
+      expect(Apartment.num_parallel_in_processes).to be <= ActiveRecord::Base.connection_pool.size
     end
 
     context "databases" do


### PR DESCRIPTION
Hi,
This PR is aim to support parallel task such as migrate and rollback.
It is similar to the idea in #388 
However, I integrated the parallel migration into original rake task.
And the number of concurrent tasks is defined in apartment configuration file. 
In addition, if a user does not want to use parallel execution, it fallbacks to original single-thread iteration with calling Parallel#each. 

Why I'm doing so is because that in part of our projects it is tedious to change every "rake db:migrate" to "rake db:migrate:parallel" (even if we already using Capistrano). So we prefer to use configuration file to change the default behavior of db:migrate (and other tasks, too).

The performance should be same as that of #388. 
The speed up comes from concurrent operation to database.
(Since we usually have a powerful database to support the parallel migration)
But in our project with 80000+ schemata (postgres), we gain over 500% speed up with 20 concurrent tasks.
(Our DB server is Amazon RDS t2.medium with 4GB RAM)
