### PR TITLE
Fix Remote connection establish connection on reload multi server

### DIFF
--- a/lib/apartment/adapters/mysql2_adapter.rb
+++ b/lib/apartment/adapters/mysql2_adapter.rb
@@ -37,6 +37,9 @@ module Apartment
       #   Reset current tenant to the default_tenant
       #
       def reset
+        # This method is changed to establish different remote servers connections for which config is changed
+        Apartment.establish_connection(@config)
+        p "ApartmentConfigHost::#{@config['host']}"
         Apartment.connection.execute "use `#{default_tenant}`"
       end
 

--- a/lib/apartment/adapters/mysql2_adapter.rb
+++ b/lib/apartment/adapters/mysql2_adapter.rb
@@ -39,7 +39,7 @@ module Apartment
       def reset
         # This method is changed to establish different remote servers connections for which config is changed
         Apartment.establish_connection(@config)
-        p "ApartmentConfigHost::#{@config['host']}"
+        p "Tenant Connection Host:: #{@config[:host]}"
         Apartment.connection.execute "use `#{default_tenant}`"
       end
 

--- a/lib/apartment/tenant.rb
+++ b/lib/apartment/tenant.rb
@@ -51,7 +51,7 @@ module Apartment
     #   Reset config and adapter so they are regenerated
     #
     def reload!(config = nil)
-      Thread.current[:apartment_adapter] = nil
+      Thread.current[:apartment_adapter] = mysql2_adapter(config)
       @config = config
     end
 


### PR DESCRIPTION
For Remote connections on reset the connection , We need to establish connection. I have updated reset method where `user database_name` is used.
For https://github.com/influitive/apartment/issues/240#issuecomment-301719422 issue  I have udpated the code