### PR TITLE
Support multi instance for mysql

### DIFF
--- a/lib/apartment/adapters/mysql2_adapter.rb
+++ b/lib/apartment/adapters/mysql2_adapter.rb
@@ -37,7 +37,9 @@ module Apartment
       #   Reset current tenant to the default_tenant
       #
       def reset
-        Apartment.connection.execute "use `#{default_tenant}`"
+        super.tap do
+          Apartment.connection.execute "use `#{default_tenant}`"
+        end
       end
 
     protected


### PR DESCRIPTION
Database changing by just  MySQL command `USE XXXX;`, and connection setting is not changed. In the case of different instances, it tries to refer to a database in another instance.
Therefore, we modified to change the connection setting as well.

TODO: Spec