### PR TITLE
Keep query cache config after switching databases

### DIFF
--- a/lib/apartment/adapters/abstract_adapter.rb
+++ b/lib/apartment/adapters/abstract_adapter.rb
@@ -152,8 +152,12 @@ module Apartment
       #   @param {String} tenant Database name
       #
       def connect_to_new(tenant)
+        query_cache_enabled = ActiveRecord::Base.connection.query_cache_enabled
+
         Apartment.establish_connection multi_tenantify(tenant)
         Apartment.connection.active?   # call active? to manually check if this connection is valid
+
+        Apartment.connection.enable_query_cache! if query_cache_enabled
       rescue *rescuable_exceptions => exception
         Apartment::Tenant.reset if reset_on_connection_exception?
         raise_connect_error!(tenant, exception)

--- a/spec/integration/query_caching_spec.rb
+++ b/spec/integration/query_caching_spec.rb
@@ -1,41 +1,81 @@
 require 'spec_helper'
 
 describe 'query caching' do
-  let(:db_names) { [db1, db2] }
+  describe 'when use_schemas = true' do
+    let(:db_names) { [db1, db2] }
 
-  before do
-    Apartment.configure do |config|
-      config.excluded_models = ["Company"]
-      config.tenant_names = lambda{ Company.pluck(:database) }
-      config.use_schemas = true
+    before do
+      Apartment.configure do |config|
+        config.excluded_models = ["Company"]
+        config.tenant_names = lambda{ Company.pluck(:database) }
+        config.use_schemas = true
+      end
+
+      Apartment::Tenant.reload!(config)
+
+      db_names.each do |db_name|
+        Apartment::Tenant.create(db_name)
+        Company.create database: db_name
+      end
     end
 
-    Apartment::Tenant.reload!(config)
+    after do
+      db_names.each{ |db| Apartment::Tenant.drop(db) }
+      Apartment::Tenant.reset
+      Company.delete_all
+    end
 
-    db_names.each do |db_name|
+    it 'clears the ActiveRecord::QueryCache after switching databases' do
+      db_names.each do |db_name|
+        Apartment::Tenant.switch! db_name
+        User.create! name: db_name
+      end
+
+      ActiveRecord::Base.connection.enable_query_cache!
+
+      Apartment::Tenant.switch! db_names.first
+      expect(User.find_by_name(db_names.first).name).to eq(db_names.first)
+
+      Apartment::Tenant.switch! db_names.last
+      expect(User.find_by_name(db_names.first)).to be_nil
+    end
+  end
+
+  describe 'when use_schemas = false' do
+    let(:db_name) { db1 }
+
+    before do
+      Apartment.configure do |config|
+        config.excluded_models = ["Company"]
+        config.tenant_names = lambda{ Company.pluck(:database) }
+        config.use_schemas = false
+      end
+
+      Apartment::Tenant.reload!(config)
+
       Apartment::Tenant.create(db_name)
       Company.create database: db_name
     end
-  end
 
-  after do
-    db_names.each{ |db| Apartment::Tenant.drop(db) }
-    Apartment::Tenant.reset
-    Company.delete_all
-  end
+    after do
+      # Avoid cannot drop the currently open database. Maybe there is a better way to handle this.
+      Apartment::Tenant.switch! 'template1'
 
-  it 'clears the ActiveRecord::QueryCache after switching databases' do
-    db_names.each do |db_name|
-      Apartment::Tenant.switch! db_name
-      User.create! name: db_name
+      Apartment::Tenant.drop(db_name)
+      Apartment::Tenant.reset
+      Company.delete_all
     end
 
-    ActiveRecord::Base.connection.enable_query_cache!
+    it "configuration value is kept after switching databases" do
+      ActiveRecord::Base.connection.enable_query_cache!
 
-    Apartment::Tenant.switch! db_names.first
-    expect(User.find_by_name(db_names.first).name).to eq(db_names.first)
+      Apartment::Tenant.switch! db_name
+      expect(Apartment.connection.query_cache_enabled).to be true
 
-    Apartment::Tenant.switch! db_names.last
-    expect(User.find_by_name(db_names.first)).to be_nil
+      ActiveRecord::Base.connection.disable_query_cache!
+
+      Apartment::Tenant.switch! db_name
+      expect(Apartment.connection.query_cache_enabled).to be false
+    end
   end
 end


### PR DESCRIPTION
When use_schemas = false, switching databases would always disable query cache. Even if it was previously enabled.

connect_to_new method was changed to check the current configuration and keep it after the new connection is established.