### PR TITLE
PostgreSQL < 9.3 does not respect a new search_path for prepared statements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,3 +23,4 @@ matrix:
     - rvm: 2.1.9
       gemfile: gemfiles/rails_5_0.gemfile
   fast_finish: true
+cache: bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ rvm:
   - 2.2.4
   - 2.3.1
   - jruby-9.0.5.0
+  - jruby-9.1.9.0
 gemfile:
   - gemfiles/rails_4_0.gemfile
   - gemfiles/rails_4_1.gemfile
@@ -21,6 +22,12 @@ matrix:
     - rvm: 2.0.0
       gemfile: gemfiles/rails_5_0.gemfile
     - rvm: 2.1.9
+      gemfile: gemfiles/rails_5_0.gemfile
+    - rvm: jruby-9.0.5.0
+      gemfile: gemfiles/rails_4_2.gemfile
+    - rvm: jruby-9.0.5.0
+      gemfile: gemfiles/rails_5_0.gemfile
+    - rvm: jruby-9.1.9.0
       gemfile: gemfiles/rails_5_0.gemfile
   fast_finish: true
 cache: bundler

--- a/Rakefile
+++ b/Rakefile
@@ -51,7 +51,13 @@ namespace :postgres do
 
   desc 'Build the PostgreSQL test databases'
   task :build_db do
-    %x{ createdb -E UTF8 #{pg_config['database']} -U#{pg_config['username']} } rescue "test db already exists"
+    params = []
+    params << "-E UTF8"
+    params << pg_config['database']
+    params << "-U#{pg_config['username']}"
+    params << "-h#{pg_config['host']}" if pg_config['host']
+    params << "-p#{pg_config['port']}" if pg_config['port']
+    %x{ createdb #{params.join(' ')} } rescue "test db already exists"
     ActiveRecord::Base.establish_connection pg_config
     ActiveRecord::Migrator.migrate('spec/dummy/db/migrate')
   end
@@ -59,7 +65,12 @@ namespace :postgres do
   desc "drop the PostgreSQL test database"
   task :drop_db do
     puts "dropping database #{pg_config['database']}"
-    %x{ dropdb #{pg_config['database']} -U#{pg_config['username']} }
+    params = []
+    params << pg_config['database']
+    params << "-U#{pg_config['username']}"
+    params << "-h#{pg_config['host']}" if pg_config['host']
+    params << "-p#{pg_config['port']}" if pg_config['port']
+    %x{ dropdb #{params.join(' ')} }
   end
 
 end
@@ -70,7 +81,11 @@ namespace :mysql do
 
   desc 'Build the MySQL test databases'
   task :build_db do
-    %x{ mysqladmin -u #{my_config['username']} --password=#{my_config['password']} create #{my_config['database']} } rescue "test db already exists"
+    params = []
+    params << "-h #{my_config['host']}" if my_config['host']
+    params << "-u #{my_config['username']}" if my_config['username']
+    params << "-p#{my_config['password']}" if my_config['password']
+    %x{ mysqladmin #{params.join(' ')} create #{my_config['database']} } rescue "test db already exists"
     ActiveRecord::Base.establish_connection my_config
     ActiveRecord::Migrator.migrate('spec/dummy/db/migrate')
   end
@@ -78,7 +93,11 @@ namespace :mysql do
   desc "drop the MySQL test database"
   task :drop_db do
     puts "dropping database #{my_config['database']}"
-    %x{ mysqladmin -u #{my_config['username']} --password=#{my_config['password']} drop #{my_config['database']} --force}
+    params = []
+    params << "-h #{my_config['host']}" if my_config['host']
+    params << "-u #{my_config['username']}" if my_config['username']
+    params << "-p#{my_config['password']}" if my_config['password']
+    %x{ mysqladmin #{params.join(' ')} drop #{my_config['database']} --force}
   end
 
 end

--- a/apartment.gemspec
+++ b/apartment.gemspec
@@ -41,4 +41,9 @@ Gem::Specification.new do |s|
     s.add_development_dependency 'pg',     '>= 0.11.0'
     s.add_development_dependency 'sqlite3'
   end
+
+  if RUBY_VERSION < '2.1.0'
+    # capybara depends on xpath depends on nokogiri
+    s.add_development_dependency 'nokogiri', '< 1.7.0'
+  end
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '2'
+services:
+  postgresql:
+    image: postgres:9.2
+    environment:
+      POSTGRES_PASSWORD: ""
+    ports:
+      - "5432:5432"
+  mysql:
+    image: mysql:5.7
+    environment:
+      MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+    ports:
+      - "3306:3306"

--- a/lib/apartment/adapters/postgresql_adapter.rb
+++ b/lib/apartment/adapters/postgresql_adapter.rb
@@ -68,6 +68,13 @@ module Apartment
         @current = tenant.to_s
         Apartment.connection.schema_search_path = full_search_path
 
+        # When the PostgreSQL version is < 9.3,
+        # there is a issue for prepared statement with changing search_path.
+        # https://www.postgresql.org/docs/9.3/static/sql-prepare.html
+        if postgresql_version < 90300
+          Apartment.connection.clear_cache!
+        end
+
       rescue *rescuable_exceptions
         raise TenantNotFound, "One of the following schema(s) is invalid: \"#{tenant}\" #{full_search_path}"
       end
@@ -86,6 +93,12 @@ module Apartment
 
       def persistent_schemas
         [@current, Apartment.persistent_schemas].flatten
+      end
+
+      def postgresql_version
+        # ActiveRecord::ConnectionAdapters::PostgreSQLAdapter#postgresql_version is
+        # public from Rails 5.0.
+        Apartment.connection.send(:postgresql_version)
       end
     end
 

--- a/spec/adapters/mysql2_adapter_spec.rb
+++ b/spec/adapters/mysql2_adapter_spec.rb
@@ -32,6 +32,14 @@ describe Apartment::Adapters::Mysql2Adapter, database: :mysql do
           end
         end
 
+        after do
+          # Apartment::Tenant.init creates per model connection.
+          # Remove the connection after testing not to unintentionally keep the connection across tests.
+          Apartment.excluded_models.each do |excluded_model|
+            excluded_model.constantize.remove_connection
+          end
+        end
+
         it "should process model exclusions" do
           Apartment::Tenant.init
 

--- a/spec/dummy/config/database.yml.sample
+++ b/spec/dummy/config/database.yml.sample
@@ -25,6 +25,7 @@ development:
 test:
   adapter: postgresql
   database: apartment_postgresql_test
+  username: postgres
   min_messages: WARNING
   pool: 5
   timeout: 5000
@@ -32,6 +33,7 @@ test:
 development:
   adapter: postgresql
   database: apartment_postgresql_development
+  username: postgres
   min_messages: WARNING
   pool: 5
   timeout: 5000

--- a/spec/dummy/db/migrate/20110613152810_create_dummy_models.rb
+++ b/spec/dummy/db/migrate/20110613152810_create_dummy_models.rb
@@ -1,4 +1,5 @@
-class CreateDummyModels < ActiveRecord::Migration
+migration_class = (ActiveRecord::VERSION::MAJOR >= 5) ?  ActiveRecord::Migration[4.2] : ActiveRecord::Migration
+class CreateDummyModels < migration_class
   def self.up
     create_table :companies do |t|
       t.boolean :dummy

--- a/spec/dummy/db/migrate/20111202022214_create_table_books.rb
+++ b/spec/dummy/db/migrate/20111202022214_create_table_books.rb
@@ -1,4 +1,5 @@
-class CreateTableBooks < ActiveRecord::Migration
+migration_class = (ActiveRecord::VERSION::MAJOR >= 5) ?  ActiveRecord::Migration[4.2] : ActiveRecord::Migration
+class CreateTableBooks < migration_class
   def up
     create_table :books do |t|
       t.string :name

--- a/spec/examples/connection_adapter_examples.rb
+++ b/spec/examples/connection_adapter_examples.rb
@@ -6,6 +6,14 @@ shared_examples_for "a connection based apartment adapter" do
   let(:default_tenant){ subject.switch{ ActiveRecord::Base.connection.current_database } }
 
   describe "#init" do
+    after do
+      # Apartment::Tenant.init creates per model connection.
+      # Remove the connection after testing not to unintentionally keep the connection across tests.
+      Apartment.excluded_models.each do |excluded_model|
+        excluded_model.constantize.remove_connection
+      end
+    end
+
     it "should process model exclusions" do
       Apartment.configure do |config|
         config.excluded_models = ["Company"]

--- a/spec/examples/schema_adapter_examples.rb
+++ b/spec/examples/schema_adapter_examples.rb
@@ -15,6 +15,14 @@ shared_examples_for "a schema based apartment adapter" do
       end
     end
 
+    after do
+      # Apartment::Tenant.init creates per model connection.
+      # Remove the connection after testing not to unintentionally keep the connection across tests.
+      Apartment.excluded_models.each do |excluded_model|
+        excluded_model.constantize.remove_connection
+      end
+    end
+
     it "should process model exclusions" do
       Apartment::Tenant.init
 

--- a/spec/tenant_spec.rb
+++ b/spec/tenant_spec.rb
@@ -59,8 +59,7 @@ describe Apartment::Tenant do
 
     describe "#adapter" do
       it "should load postgresql adapter" do
-        subject.adapter
-        expect(Apartment::Adapters::PostgresqlAdapter).to be_a(Class)
+        expect(subject.adapter).to be_a(Apartment::Adapters::PostgresqlSchemaAdapter)
       end
 
       it "raises exception with invalid adapter specified" do

--- a/spec/tenant_spec.rb
+++ b/spec/tenant_spec.rb
@@ -136,6 +136,14 @@ describe Apartment::Tenant do
             subject.init
           end
 
+          after do
+            # Apartment::Tenant.init creates per model connection.
+            # Remove the connection after testing not to unintentionally keep the connection across tests.
+            Apartment.excluded_models.each do |excluded_model|
+              excluded_model.constantize.remove_connection
+            end
+          end
+
           it "should create excluded models in public schema" do
             subject.reset # ensure we're on public schema
             count = Company.count + x.times{ Company.create }


### PR DESCRIPTION
@mikecmpbll 

I finally straighten out the failing spec with PostgreSQL + Rails 5.0 + Apartment that I described in #448.

The issue is caused by older PostgreSQL version (< 9.3). That version of PostgreSQL behaves a supprising behavior ([as official document described](https://www.postgresql.org/docs/9.3/static/release-9-3.html) in E.18.2.2. Other) for the cached statements.

> Force cached plans to be replanned if the search_path changes (Tom Lane)
> Previously, cached plans already generated in the current session were not redone if the query was re-executed with a new search_path setting, resulting in surprising behavior.

And the `PREPARE` statement documentation is here: https://www.postgresql.org/docs/9.3/static/sql-prepare.html

**Remarkable point:**
> Also, if the value of search_path changes from one use to the next, the statement will be re-parsed using the new search_path. (This latter behavior is new as of PostgreSQL 9.3.)

So, clearing the cache of prepared statements for the older version of PostgreSQL is to solve the problem about the tests.

You can confirm what the statements are cached in the specs by adding the lines below.
```ruby
p Apartment.connection.instance_variable_get(:@statements)
```

The query for the `ar_internal_metadata` are cached and executed for a removed schema under PostgreSQL 9.1 (default version for the Travis-CI), so the test is failed with `PG::UndefinedTable: ERROR:  relation "ar_internal_metadata" does not exist at character 39`.

---

And I fixed some rarely (occasionally?) failing spec.