### PR TITLE
Remove deprecation warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
   - gem install bundler -v '> 1.5.0'
 env:
   RUBY_GC_MALLOC_LIMIT: 90000000
-  RUBY_FREE_MIN: 200000
+  RUBY_GC_HEAP_FREE_SLOTS: 200000
 matrix:
   allow_failures:
     - rvm: ruby-head

--- a/lib/apartment/adapters/postgresql_adapter.rb
+++ b/lib/apartment/adapters/postgresql_adapter.rb
@@ -18,7 +18,7 @@ module Apartment
     private
 
       def rescue_from
-        PGError
+        PG::Error
       end
     end
 

--- a/spec/tenant_spec.rb
+++ b/spec/tenant_spec.rb
@@ -67,7 +67,7 @@ describe Apartment::Tenant do
 
         expect {
           Apartment::Tenant.adapter
-        }.to raise_error
+        }.to raise_error(RuntimeError)
       end
 
       context "threadsafety" do

--- a/spec/unit/elevators/subdomain_spec.rb
+++ b/spec/unit/elevators/subdomain_spec.rb
@@ -33,26 +33,26 @@ describe Apartment::Elevators::Subdomain do
     context "assuming two subdomains" do
       it "should parse two subdomains in the two level domain" do
         request = ActionDispatch::Request.new('HTTP_HOST' => 'foo.xyz.bar.com')
-        elevator.parse_tenant_name(request).should == "foo"
+        expect(elevator.parse_tenant_name(request)).to eq("foo")
       end
 
       it "should parse two subdomains in the third level domain" do
         request = ActionDispatch::Request.new('HTTP_HOST' => 'foo.xyz.bar.co.uk')
-        elevator.parse_tenant_name(request).should == "foo"
+        expect(elevator.parse_tenant_name(request)).to eq("foo")
       end
     end
 
     context "assuming localhost" do
       it "should return nil for localhost" do
         request = ActionDispatch::Request.new('HTTP_HOST' => 'localhost')
-        elevator.parse_tenant_name(request).should be_nil
+        expect(elevator.parse_tenant_name(request)).to be_nil
       end
     end
 
     context "assuming ip address" do
       it "should return nil for an ip address" do
         request = ActionDispatch::Request.new('HTTP_HOST' => '127.0.0.1')
-        elevator.parse_tenant_name(request).should be_nil
+        expect(elevator.parse_tenant_name(request)).to be_nil
       end
     end
   end


### PR DESCRIPTION
Remove deprecated/obsolete methods/constants of Ruby, RSpec and pg.