### PR TITLE
Fix an `apartment:create` task

### DIFF
--- a/lib/tasks/apartment.rake
+++ b/lib/tasks/apartment.rake
@@ -7,7 +7,7 @@ apartment_namespace = namespace :apartment do
     tenants.each do |tenant|
       begin
         puts("Creating #{tenant} tenant")
-        quietly { Apartment::Tenant.create(tenant) }
+        Apartment::Tenant.create(tenant)
       rescue Apartment::TenantExists => e
         puts e.message
       end

--- a/lib/tasks/apartment.rake
+++ b/lib/tasks/apartment.rake
@@ -3,7 +3,7 @@ require 'apartment/migrator'
 apartment_namespace = namespace :apartment do
 
   desc "Create all tenants"
-  task create: 'db:migrate' do
+  task :create do
     tenants.each do |tenant|
       begin
         puts("Creating #{tenant} tenant")


### PR DESCRIPTION
This PR fixes following issues:
- apartment:create uses deprecated method
- apartment:create has wrong task dependency

---

As described in #424, The PR commits of #55 are merged into `master` branch.
This branch fixes `development` branch about that.
And, I removed wrong task dependency.

This closes #424.