### PR TITLE
Add a gem version badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ In the examples above, we show the Apartment middleware being appended to the Ra
 Rails.application.config.middleware.use Apartment::Elevators::Subdomain
 ```
 
-By default, the Subdomain middleware switches into a Tenant based on the subdomain at the beginning of the request, and when the request is finished, it switches back to the "public" Tenant. This happens in the [Generic](https://github.com/influitive/apartment/blob/development/lib/apartment/elevators/generic.rb#L22) elevator, so all elevators that inherit from this elevator will operate as such. 
+By default, the Subdomain middleware switches into a Tenant based on the subdomain at the beginning of the request, and when the request is finished, it switches back to the "public" Tenant. This happens in the [Generic](https://github.com/influitive/apartment/blob/development/lib/apartment/elevators/generic.rb#L22) elevator, so all elevators that inherit from this elevator will operate as such.
 
 It's also good to note that Apartment switches back to the "public" tenant any time an error is raised in your application.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Apartment
 
+[![Gem Version](https://badge.fury.io/rb/apartment.svg)](https://badge.fury.io/rb/apartment)
 [![Code Climate](https://codeclimate.com/github/influitive/apartment/badges/gpa.svg)](https://codeclimate.com/github/influitive/apartment)
 [![Build Status](https://travis-ci.org/influitive/apartment.svg?branch=development)](https://travis-ci.org/influitive/apartment)
 


### PR DESCRIPTION
To make the most of README.md, I added the gem version badge to README.md.
This is useful when the user jumps into https://rubygems.org/gems/apartment, imho.

Please feel free to reject this, if we don't need.