### PR TITLE
Raise FileNotFound when apartment cannot find the file to be loaded

### DIFF
--- a/lib/apartment.rb
+++ b/lib/apartment.rb
@@ -99,6 +99,9 @@ module Apartment
   # Raised when apartment cannot find the adapter specified in <tt>config/database.yml</tt>
   AdapterNotFound = Class.new(ApartmentError)
 
+  # Raised when apartment cannot find the file to be loaded
+  FileNotFound = Class.new(ApartmentError)
+
   # Tenant specified is unknown
   TenantNotFound = Class.new(ApartmentError)
 

--- a/lib/apartment/adapters/abstract_adapter.rb
+++ b/lib/apartment/adapters/abstract_adapter.rb
@@ -116,7 +116,7 @@ module Apartment
       #
       def seed_data
         # Don't log the output of seeding the db
-        silence_warnings{ load_or_abort(Apartment.seed_data_file) } if Apartment.seed_data_file
+        silence_warnings{ load_or_raise(Apartment.seed_data_file) } if Apartment.seed_data_file
       end
       alias_method :seed, :seed_data
 
@@ -187,7 +187,7 @@ module Apartment
       def import_database_schema
         ActiveRecord::Schema.verbose = false    # do not log schema load output.
 
-        load_or_abort(Apartment.database_schema_file) if Apartment.database_schema_file
+        load_or_raise(Apartment.database_schema_file) if Apartment.database_schema_file
       end
 
       #   Return a new config that is multi-tenanted
@@ -206,15 +206,17 @@ module Apartment
         config[:database] = environmentify(tenant)
       end
 
-      #   Load a file or abort if it doesn't exists
+      #   Load a file or raise error if it doesn't exists
       #
-      def load_or_abort(file)
+      def load_or_raise(file)
         if File.exists?(file)
           load(file)
         else
-          abort %{#{file} doesn't exist yet}
+          raise FileNotFound, "#{file} doesn't exist yet"
         end
       end
+      # Backward compatibility
+      alias_method :load_or_abort, :load_or_raise
 
       #   Exceptions to rescue from on db operations
       #

--- a/spec/examples/generic_adapter_examples.rb
+++ b/spec/examples/generic_adapter_examples.rb
@@ -58,6 +58,22 @@ shared_examples_for "a generic apartment adapter" do
 
       subject.switch(db2){ expect(User.count).to eq(@count + 1) }
     end
+
+    it "should raise error when the schema.rb is missing unless Apartment.use_sql is set to true" do
+      next if Apartment.use_sql
+
+      subject.drop(db1)
+      begin
+        Dir.mktmpdir do |tmpdir|
+          Apartment.database_schema_file = "#{tmpdir}/schema.rb"
+          expect {
+            subject.create(db1)
+          }.to raise_error(Apartment::FileNotFound)
+        end
+      ensure
+        Apartment.remove_instance_variable(:@database_schema_file)
+      end
+    end
   end
 
   describe "#drop" do


### PR DESCRIPTION
This is an implementation of #301.
Added error that is raised when apartment can't find file to be loaded.

/cc @edave, @bradrobertson 

this closes #301.