### PR TITLE
Generated initializers/apartment.rb is misguided

### DIFF
--- a/lib/generators/apartment/install/templates/apartment.rb
+++ b/lib/generators/apartment/install/templates/apartment.rb
@@ -49,13 +49,18 @@ Apartment.configure do |config|
   #
   config.tenant_names = lambda { ToDo_Tenant_Or_User_Model.pluck :database }
 
+  # PostgreSQL:
+  #   Specifies whether to use PostgreSQL schemas or create a new database per Tenant.
   #
-  # ==> PostgreSQL only options
-
-  # Specifies whether to use PostgreSQL schemas or create a new database per Tenant.
+  # MySQL:
+  #   Specifies whether to switch databases by using `use` statement or re-establish connection.
+  #
   # The default behaviour is true.
   #
   # config.use_schemas = true
+
+  #
+  # ==> PostgreSQL only options
 
   # Apartment can be forced to use raw SQL dumps instead of schema.rb for creating new schemas.
   # Use this when you are using some extra features in PostgreSQL that can't be represented in


### PR DESCRIPTION
`Apartment.use_schemas` is also used for configuring mysql2 adapter.

https://github.com/influitive/apartment/blob/8ddb79960160a4832d2a2f842d4154c010304873/lib/apartment/adapters/mysql2_adapter.rb#L7-L9