### PR TITLE
Relax version of public_suffix gem

### DIFF
--- a/apartment.gemspec
+++ b/apartment.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   # must be >= 3.1.2 due to bug in prepared_statements
   s.add_dependency 'activerecord',    '>= 3.1.2', '< 6.0'
   s.add_dependency 'rack',            '>= 1.3.6'
-  s.add_dependency 'public_suffix',   '~> 2.0.5'
+  s.add_dependency 'public_suffix',   '>= 2'
 
   s.add_development_dependency 'appraisal'
   s.add_development_dependency 'rake',         '~> 0.9'


### PR DESCRIPTION
public_suffix v3.0 has been released in Aug 4, so relax version of public_suffix gem to `>= 2`.
https://github.com/weppos/publicsuffix-ruby/releases

Changes: https://github.com/weppos/publicsuffix-ruby/compare/v2.0.5...v3.0.0