### PR TITLE
Allow to exclude tables from new tenant schema via configuration

### DIFF
--- a/lib/apartment.rb
+++ b/lib/apartment.rb
@@ -11,7 +11,7 @@ module Apartment
     extend Forwardable
 
     ACCESSOR_METHODS  = [:use_schemas, :use_sql, :seed_after_create, :prepend_environment, :append_environment, :with_multi_server_setup ]
-    WRITER_METHODS    = [:tenant_names, :database_schema_file, :excluded_models, :default_schema, :persistent_schemas, :connection_class, :tld_length, :db_migrate_tenants, :seed_data_file]
+    WRITER_METHODS    = [:tenant_names, :database_schema_file, :excluded_models, :exclude_tables, :default_schema, :persistent_schemas, :connection_class, :tld_length, :db_migrate_tenants, :seed_data_file]
 
     attr_accessor(*ACCESSOR_METHODS)
     attr_writer(*WRITER_METHODS)
@@ -46,6 +46,10 @@ module Apartment
     # Default to empty array
     def excluded_models
       @excluded_models || []
+    end
+
+    def exclude_tables
+      @exclude_tables || false
     end
 
     def default_schema

--- a/lib/apartment/adapters/postgresql_adapter.rb
+++ b/lib/apartment/adapters/postgresql_adapter.rb
@@ -137,16 +137,18 @@ module Apartment
       #   @return {String} raw SQL contaning only postgres schema dump
       #
       def pg_dump_schema
+        # Skip excluded tables
+        if Apartment.exclude_tables
+          excluded_tables =
+            collect_table_names(Apartment.excluded_models)
+            .uniq
+            .map! {|t| "-T #{t}"}
+            .join(' ')
 
-        # Skip excluded tables? :/
-        # excluded_tables =
-        #   collect_table_names(Apartment.excluded_models)
-        #   .map! {|t| "-T #{t}"}
-        #   .join(' ')
-
-        # `pg_dump -s -x -O -n #{default_tenant} #{excluded_tables} #{dbname}`
-
-        with_pg_env { `pg_dump -s -x -O -n #{default_tenant} #{dbname}` }
+          with_pg_env { `pg_dump -s -x -O -n #{default_tenant} #{excluded_tables} #{dbname}` }
+        else
+          with_pg_env { `pg_dump -s -x -O -n #{default_tenant} #{dbname}` }
+        end
       end
 
       #   Dump data from schema_migrations table

--- a/lib/generators/apartment/install/templates/apartment.rb
+++ b/lib/generators/apartment/install/templates/apartment.rb
@@ -62,6 +62,11 @@ Apartment.configure do |config|
   #
   # ==> PostgreSQL only options
 
+  # By default Apartment will do a full dump and create very table that is in the default schema, even
+  # tables that come from excluded models. To exclude tables that come from excluded models, uncomment
+  # this line.
+  # config.exclude_tables = true
+
   # Apartment can be forced to use raw SQL dumps instead of schema.rb for creating new schemas.
   # Use this when you are using some extra features in PostgreSQL that can't be represented in
   # schema.rb, like materialized views etc. (only applies with use_schemas set to true).


### PR DESCRIPTION
This option was commented out for 4 years (don't know why though).

This would resolve a problem when DB Views are used with tables from public and tenant schemas together. By default, it seems, that PostgreSQL removes `public.` prefixes from database views when doing a `pg_dump` thus removing traces of which tables should be used from public schema and which from tenants.

Excluding certain tables would allow Postgresql to fallback through search_path and would technically eliminate the need to prefix tables from public schema. 

P.S. This is only an issue when Creating new tenants. If a new version of a View is migrated then everything works, because tenants schema view is updated with correct `public.` prefixes in its view