### PR TITLE
Add Host Elevator and refine Elevators documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ manually in your `application.rb` like so
 
 ```ruby
 # config/application.rb
-require 'apartment/elevators/subdomain' # or 'domain' or 'generic'
+require 'apartment/elevators/subdomain' # or 'domain', 'first_subdomain', 'host'
 ```
 
 #### Switch on subdomain
@@ -155,7 +155,7 @@ module MyApplication
 end
 ```
 
-If you want to exclude a domain, for example if you don't want your application to treate www like a subdomain, in an initializer in your application, you can set the following:
+If you want to exclude a domain, for example if you don't want your application to treat www like a subdomain, in an initializer in your application, you can set the following:
 
 ```ruby
 # config/initializers/apartment/subdomain_exclusions.rb
@@ -166,7 +166,7 @@ This functions much in the same way as the Subdomain elevator. **NOTE:** in fact
 
 #### Switch on domain
 
-To switch based on full domain (excluding subdomains *ie 'www'* and top level domains *ie '.com'* ) use the following:
+To switch based on full domain (excluding the 'www' subdomains and top level domains *ie '.com'* ) use the following:
 
 ```ruby
 # application.rb
@@ -176,6 +176,11 @@ module MyApplication
   end
 end
 ```
+
+Note that if you have several subdomains, then it will match on the first *non-www* subdomain:
+- example.com => example
+- www.example.com => example
+- a.example.com => a
 
 #### Switch on full host using a hash
 
@@ -189,6 +194,31 @@ module MyApplication
   end
 end
 ```
+
+#### Switch on full host, ignoring given first subdomains
+
+To switch based on full host to find corresponding tenant name use the following:
+
+```ruby
+# application.rb
+module MyApplication
+  class Application < Rails::Application
+    config.middleware.use Apartment::Elevators::Host
+  end
+end
+```
+
+If you want to exclude a first-subdomain, for example if you don't want your application to include www in the matching, in an initializer in your application, you can set the following:
+
+```ruby
+Apartment::Elevators::Host.ignored_first_subdomains = ['www']
+```
+
+With the above set, these would be the results:
+- example.com => example.com
+- www.example.com => example.com
+- a.example.com => a.example.com
+- www.a.example.com => a.example.com
 
 #### Custom Elevator
 

--- a/lib/apartment/elevators/domain.rb
+++ b/lib/apartment/elevators/domain.rb
@@ -4,9 +4,11 @@ module Apartment
   module Elevators
     #   Provides a rack based tenant switching solution based on domain
     #   Assumes that tenant name should match domain
-    #   Parses request host for second level domain
+    #   Parses request host for second level domain, ignoring www
     #   eg. example.com       => example
     #       www.example.bc.ca => example
+    #       a.example.bc.ca   => a
+    #       
     #
     class Domain < Generic
 

--- a/lib/apartment/elevators/host.rb
+++ b/lib/apartment/elevators/host.rb
@@ -1,0 +1,30 @@
+require 'apartment/elevators/generic'
+
+module Apartment
+  module Elevators
+    #   Provides a rack based tenant switching solution based on the host
+    #   Assumes that tenant name should match host
+    #   Strips/ignores first subdomains in ignored_first_subdomains
+    #   eg. example.com       => example.com
+    #       www.example.bc.ca => www.example.bc.ca
+    #   if ignored_first_subdomains = ['www']
+    #       www.example.bc.ca => example.bc.ca
+    #       www.a.b.c.d.com   => a.b.c.d.com
+    #
+    class Host < Generic
+      def self.ignored_first_subdomains
+        @ignored_first_subdomains ||= []
+      end
+
+      def self.ignored_first_subdomains=(arg)
+        @ignored_first_subdomains = arg
+      end
+
+      def parse_tenant_name(request)
+        return nil if request.host.blank?
+        parts = request.host.split('.')
+        self.class.ignored_first_subdomains.include?(parts[0]) ? parts.drop(1).join('.') : request.host
+      end
+    end
+  end
+end

--- a/lib/generators/apartment/install/templates/apartment.rb
+++ b/lib/generators/apartment/install/templates/apartment.rb
@@ -6,6 +6,7 @@
 # require 'apartment/elevators/domain'
 require 'apartment/elevators/subdomain'
 # require 'apartment/elevators/first_subdomain'
+# require 'apartment/elevators/host'
 
 #
 # Apartment Configuration
@@ -95,3 +96,4 @@ end
 # Rails.application.config.middleware.use Apartment::Elevators::Domain
 Rails.application.config.middleware.use Apartment::Elevators::Subdomain
 # Rails.application.config.middleware.use Apartment::Elevators::FirstSubdomain
+# Rails.application.config.middleware.use Apartment::Elevators::Host

--- a/spec/unit/elevators/host_spec.rb
+++ b/spec/unit/elevators/host_spec.rb
@@ -1,0 +1,89 @@
+require 'spec_helper'
+require 'apartment/elevators/host'
+
+describe Apartment::Elevators::Host do
+
+  subject(:elevator){ described_class.new(Proc.new{}) }
+
+  describe "#parse_tenant_name" do
+
+    it "should return nil when no host" do
+      request = ActionDispatch::Request.new('HTTP_HOST' => '')
+      expect(elevator.parse_tenant_name(request)).to be_nil
+    end
+
+    context "assuming no ignored_first_subdomains" do
+      context "with 3 parts" do
+        it "should return the whole host" do
+          request = ActionDispatch::Request.new('HTTP_HOST' => 'foo.bar.com')
+          expect(elevator.parse_tenant_name(request)).to eq('foo.bar.com')
+        end
+      end
+
+      context "with 6 parts" do
+        it "should return the whole host" do
+          request = ActionDispatch::Request.new('HTTP_HOST' => 'one.two.three.foo.bar.com')
+          expect(elevator.parse_tenant_name(request)).to eq('one.two.three.foo.bar.com')
+        end
+      end
+    end
+
+    context "assuming ignored_first_subdomains is set" do
+      before { described_class.ignored_first_subdomains = %w{www foo} }
+
+      context "with 3 parts" do
+        it "should return host without www" do
+          request = ActionDispatch::Request.new('HTTP_HOST' => 'www.bar.com')
+          expect(elevator.parse_tenant_name(request)).to eq('bar.com')
+        end
+
+        it "should return host without foo" do
+          request = ActionDispatch::Request.new('HTTP_HOST' => 'foo.bar.com')
+          expect(elevator.parse_tenant_name(request)).to eq('bar.com')
+        end
+      end
+
+      context "with 6 parts" do
+        it "should return host without www" do
+          request = ActionDispatch::Request.new('HTTP_HOST' => 'www.one.two.three.foo.bar.com')
+          expect(elevator.parse_tenant_name(request)).to eq('one.two.three.foo.bar.com')
+        end
+
+        it "should return host without www" do
+          request = ActionDispatch::Request.new('HTTP_HOST' => 'foo.one.two.three.bar.com')
+          expect(elevator.parse_tenant_name(request)).to eq('one.two.three.bar.com')
+        end
+      end
+    end
+
+    context "assuming localhost" do
+      it "should return localhost" do
+        request = ActionDispatch::Request.new('HTTP_HOST' => 'localhost')
+        expect(elevator.parse_tenant_name(request)).to eq('localhost')
+      end
+    end
+
+    context "assuming ip address" do
+      it "should return the ip address" do
+        request = ActionDispatch::Request.new('HTTP_HOST' => '127.0.0.1')
+        expect(elevator.parse_tenant_name(request)).to eq('127.0.0.1')
+      end
+    end
+  end
+
+  describe "#call" do
+    it "switches to the proper tenant" do
+      expect(Apartment::Tenant).to receive(:switch).with('foo.bar.com')
+      elevator.call('HTTP_HOST' => 'foo.bar.com')
+    end
+
+    it "ignores ignored_first_subdomains" do
+      described_class.ignored_first_subdomains = %w{foo}
+
+      expect(Apartment::Tenant).to receive(:switch).with('bar.com')
+      elevator.call('HTTP_HOST' => 'foo.bar.com')
+      
+      described_class.ignored_first_subdomains = nil
+    end
+  end
+end


### PR DESCRIPTION
## Why
I had to use this gem for a recent project involving multiple domains pointing to a single multi-tenant Rails app. 

Naturally, I decided to use the Domain elevator to determine the tenant to switch to. However, when the client was testing the site, he used the domain of a tenant (excluding TLD) and prepended it as a subdomain of another tenant. i.e. 

Tenant A: foo.com
Tenant B: bar.com

URL visited: foo.bar.com => Switched to Tenant A

Obviously, this was not expected behaviour, and I had to go about writing a custom elevator to use the entire host to determine the tenant. Seeing that this might potentially be a common use case for multi-tenancy, I have added my custom elevator here and updated the Elevators section of the Readme to include this misconception of what the Domain elevator does.

## Additional Features
Following how the Subdomain elevator could be configured to exclude certain subdomains, I followed the same in the Host elevator as typically you would want www.foo.com and foo.com to use the same tenant. This is done using the optional `ignored_first_subdomains`.

---

# Added documentation in Readme.md:
#### Switch on full host, ignoring given first subdomains

To switch based on full host to find corresponding tenant name use the following:

```ruby
# application.rb
module MyApplication
  class Application < Rails::Application
    config.middleware.use Apartment::Elevators::Host
  end
end
```

If you want to exclude a first-subdomain, for example if you don't want your application to include www in the matching, in an initializer in your application, you can set the following:

```ruby
Apartment::Elevators::Host.ignored_first_subdomains = ['www']
```

With the above set, these would be the results:
- example.com => example.com
- www.example.com => example.com
- a.example.com => a.example.com
- www.a.example.com => a.example.com