### PR TITLE
Add ignore_private option to parse_host

### DIFF
--- a/lib/apartment/elevators/subdomain.rb
+++ b/lib/apartment/elevators/subdomain.rb
@@ -55,7 +55,7 @@ module Apartment
       end
 
       def parse_host(host)
-        (PublicSuffix.parse(host).trd || '').split('.')
+        (PublicSuffix.parse(host, ignore_private: true).trd || '').split('.')
       end
     end
   end


### PR DESCRIPTION
I used heroku review app.
Heroku review app's URL is "https://example-pr-1234.herokuapp.com". (example)
"herokuapp.com" is eTLD, so PublicSuffix parse to trd is nil without ignore_private option.
see: https://github.com/weppos/publicsuffix-ruby#private-domains

```
irb(main):002:0> PublicSuffix.parse("test.herokuapp.com", ignore_private: false)
=> #<PublicSuffix::Domain:0x007ffa8f9d90b8 @tld="herokuapp.com", @sld="test", @trd=nil>

irb(main):003:0> PublicSuffix.parse("test.herokuapp.com", ignore_private: true)
=> #<PublicSuffix::Domain:0x007ffa8f96e858 @tld="com", @sld="herokuapp", @trd="test">
```