### PR TITLE
Fix build failure

### DIFF
--- a/gemfiles/rails_4_0.gemfile
+++ b/gemfiles/rails_4_0.gemfile
@@ -4,6 +4,10 @@ source "http://rubygems.org"
 
 gem "rails", "~> 4.0.0"
 
+if Gem::Version.create(RUBY_VERSION) < Gem::Version.create("2.1.0")
+  gem "public_suffix", "~> 2.0"
+end
+
 group :local do
   gem "pry"
   gem "guard-rspec", "~> 4.2"

--- a/gemfiles/rails_4_1.gemfile
+++ b/gemfiles/rails_4_1.gemfile
@@ -4,6 +4,10 @@ source "http://rubygems.org"
 
 gem "rails", "~> 4.1.0"
 
+if Gem::Version.create(RUBY_VERSION) < Gem::Version.create("2.1.0")
+  gem "public_suffix", "~> 2.0"
+end
+
 group :local do
   gem "pry"
   gem "guard-rspec", "~> 4.2"

--- a/gemfiles/rails_4_2.gemfile
+++ b/gemfiles/rails_4_2.gemfile
@@ -4,6 +4,10 @@ source "http://rubygems.org"
 
 gem "rails", "~> 4.2.0"
 
+if Gem::Version.create(RUBY_VERSION) < Gem::Version.create("2.1.0")
+  gem "public_suffix",   '~> 2.0'
+end
+
 group :local do
   gem "pry"
   gem "guard-rspec", "~> 4.2"

--- a/spec/unit/elevators/host_spec.rb
+++ b/spec/unit/elevators/host_spec.rb
@@ -13,6 +13,8 @@ describe Apartment::Elevators::Host do
     end
 
     context "assuming no ignored_first_subdomains" do
+      before { allow(described_class).to receive(:ignored_first_subdomains).and_return([]) }
+
       context "with 3 parts" do
         it "should return the whole host" do
           request = ActionDispatch::Request.new('HTTP_HOST' => 'foo.bar.com')
@@ -29,7 +31,7 @@ describe Apartment::Elevators::Host do
     end
 
     context "assuming ignored_first_subdomains is set" do
-      before { described_class.ignored_first_subdomains = %w{www foo} }
+      before { allow(described_class).to receive(:ignored_first_subdomains).and_return(%w{www foo}) }
 
       context "with 3 parts" do
         it "should return host without www" do
@@ -73,17 +75,15 @@ describe Apartment::Elevators::Host do
 
   describe "#call" do
     it "switches to the proper tenant" do
+      allow(described_class).to receive(:ignored_first_subdomains).and_return([])
       expect(Apartment::Tenant).to receive(:switch).with('foo.bar.com')
       elevator.call('HTTP_HOST' => 'foo.bar.com')
     end
 
     it "ignores ignored_first_subdomains" do
-      described_class.ignored_first_subdomains = %w{foo}
-
+      allow(described_class).to receive(:ignored_first_subdomains).and_return(%w{foo})
       expect(Apartment::Tenant).to receive(:switch).with('bar.com')
       elevator.call('HTTP_HOST' => 'foo.bar.com')
-      
-      described_class.ignored_first_subdomains = nil
     end
   end
 end


### PR DESCRIPTION
Fix build failure.

Apartment development branch is randomly failing build now since #477 is merged.
Changing class variable in some examples occurs a side effect to others.
This fixes it by mocking.

And one more reason of the build failure is that [public_suffix requires ruby >= 2.1 from its 3.0.0 version](https://rubygems.org/gems/public_suffix/versions/3.0.0). So we need to strict version of public_suffix for Ruby < 2.1.0 builds.