### PR TITLE
Support ActiveRecord-5.2 migration context

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -59,7 +59,7 @@ namespace :postgres do
     params << "-p#{pg_config['port']}" if pg_config['port']
     %x{ createdb #{params.join(' ')} } rescue "test db already exists"
     ActiveRecord::Base.establish_connection pg_config
-    ActiveRecord::Migrator.migrate('spec/dummy/db/migrate')
+    migrate
   end
 
   desc "drop the PostgreSQL test database"
@@ -87,7 +87,7 @@ namespace :mysql do
     params << "-p#{my_config['password']}" if my_config['password']
     %x{ mysqladmin #{params.join(' ')} create #{my_config['database']} } rescue "test db already exists"
     ActiveRecord::Base.establish_connection my_config
-    ActiveRecord::Migrator.migrate('spec/dummy/db/migrate')
+    migrate
   end
 
   desc "drop the MySQL test database"
@@ -113,4 +113,16 @@ end
 
 def my_config
   config['mysql']
+end
+
+def activerecord_below_5_2?
+  ActiveRecord.version.release() < Gem::Version.new('5.2.0')
+end
+
+def migrate
+  if activerecord_below_5_2?
+    ActiveRecord::Migrator.migrate('spec/dummy/db/migrate')
+  else
+    ActiveRecord::MigrationContext.new('spec/dummy/db/migrate').migrate
+  end
 end

--- a/lib/apartment/migrator.rb
+++ b/lib/apartment/migrator.rb
@@ -10,8 +10,12 @@ module Apartment
       Tenant.switch(database) do
         version = ENV["VERSION"] ? ENV["VERSION"].to_i : nil
 
-        ActiveRecord::Migrator.migrate(ActiveRecord::Migrator.migrations_paths, version) do |migration|
-          ENV["SCOPE"].blank? || (ENV["SCOPE"] == migration.scope)
+        migration_scope_block = -> (migration) { ENV["SCOPE"].blank? || (ENV["SCOPE"] == migration.scope) }
+
+        if activerecord_below_5_2?
+          ActiveRecord::Migrator.migrate(ActiveRecord::Migrator.migrations_paths, version, &migration_scope_block)
+        else
+          ActiveRecord::Base.connection.migration_context.migrate(version, &migration_scope_block)
         end
       end
     end
@@ -19,15 +23,29 @@ module Apartment
     # Migrate up/down to a specific version
     def run(direction, database, version)
       Tenant.switch(database) do
-        ActiveRecord::Migrator.run(direction, ActiveRecord::Migrator.migrations_paths, version)
+        if activerecord_below_5_2?
+          ActiveRecord::Migrator.run(direction, ActiveRecord::Migrator.migrations_paths, version)
+        else
+          ActiveRecord::Base.connection.migration_context.run(direction, version)
+        end
       end
     end
 
     # rollback latest migration `step` number of times
     def rollback(database, step = 1)
       Tenant.switch(database) do
-        ActiveRecord::Migrator.rollback(ActiveRecord::Migrator.migrations_paths, step)
+        if activerecord_below_5_2?
+          ActiveRecord::Migrator.rollback(ActiveRecord::Migrator.migrations_paths, step)
+        else
+          ActiveRecord::Base.connection.migration_context.rollback(step)
+        end
       end
+    end
+
+    private
+
+    def activerecord_below_5_2?
+      ActiveRecord.version.release() < Gem::Version.new('5.2.0')
     end
   end
 end

--- a/spec/unit/migrator_spec.rb
+++ b/spec/unit/migrator_spec.rb
@@ -8,30 +8,70 @@ describe Apartment::Migrator do
   # Don't need a real switch here, just testing behaviour
   before { allow(Apartment::Tenant.adapter).to receive(:connect_to_new) }
 
-  describe "::migrate" do
-    it "switches and migrates" do
-      expect(Apartment::Tenant).to receive(:switch).with(tenant).and_call_original
-      expect(ActiveRecord::Migrator).to receive(:migrate)
+  context "with ActiveRecord below 5.2.0" do
+    before do
+      allow(ActiveRecord::Migrator).to receive(:migrations_paths) { %w(spec/dummy/db/migrate) }
+      allow(Apartment::Migrator).to receive(:activerecord_below_5_2?) { true }
+    end
 
-      Apartment::Migrator.migrate(tenant)
+    describe "::migrate" do
+      it "switches and migrates" do
+        expect(Apartment::Tenant).to receive(:switch).with(tenant).and_call_original
+        expect(ActiveRecord::Migrator).to receive(:migrate)
+
+        Apartment::Migrator.migrate(tenant)
+      end
+    end
+
+    describe "::run" do
+      it "switches and runs" do
+        expect(Apartment::Tenant).to receive(:switch).with(tenant).and_call_original
+        expect(ActiveRecord::Migrator).to receive(:run).with(:up, anything, 1234)
+
+        Apartment::Migrator.run(:up, tenant, 1234)
+      end
+    end
+
+    describe "::rollback" do
+      it "switches and rolls back" do
+        expect(Apartment::Tenant).to receive(:switch).with(tenant).and_call_original
+        expect(ActiveRecord::Migrator).to receive(:rollback).with(anything, 2)
+
+        Apartment::Migrator.rollback(tenant, 2)
+      end
     end
   end
 
-  describe "::run" do
-    it "switches and runs" do
-      expect(Apartment::Tenant).to receive(:switch).with(tenant).and_call_original
-      expect(ActiveRecord::Migrator).to receive(:run).with(:up, anything, 1234)
-
-      Apartment::Migrator.run(:up, tenant, 1234)
+  context "with ActiveRecord abowe or equal to 5.2.0" do
+    before do
+      allow(Apartment::Migrator).to receive(:activerecord_below_5_2?) { false }
     end
-  end
 
-  describe "::rollback" do
-    it "switches and rolls back" do
-      expect(Apartment::Tenant).to receive(:switch).with(tenant).and_call_original
-      expect(ActiveRecord::Migrator).to receive(:rollback).with(anything, 2)
+    describe "::migrate" do
+      it "switches and migrates" do
+        expect(Apartment::Tenant).to receive(:switch).with(tenant).and_call_original
+        expect_any_instance_of(ActiveRecord::MigrationContext).to receive(:migrate)
 
-      Apartment::Migrator.rollback(tenant, 2)
+        Apartment::Migrator.migrate(tenant)
+      end
+    end
+
+    describe "::run" do
+      it "switches and runs" do
+        expect(Apartment::Tenant).to receive(:switch).with(tenant).and_call_original
+        expect_any_instance_of(ActiveRecord::MigrationContext).to receive(:run).with(:up, 1234)
+
+        Apartment::Migrator.run(:up, tenant, 1234)
+      end
+    end
+
+    describe "::rollback" do
+      it "switches and rolls back" do
+        expect(Apartment::Tenant).to receive(:switch).with(tenant).and_call_original
+        expect_any_instance_of(ActiveRecord::MigrationContext).to receive(:rollback).with(2)
+
+        Apartment::Migrator.rollback(tenant, 2)
+      end
     end
   end
 end


### PR DESCRIPTION
ActiveRecord 5.2 Migrator API has changed and now MigrationContext class must be used.

Check #522 

Actual error from migration tasks:
```ruby
NoMethodError: undefined method `migrate' for ActiveRecord::Migrator:Class
.rvm/gems/ruby-2.5.0/gems/apartment-2.1.0/lib/apartment/migrator.rb:13:in `block in migrate'
.rvm/gems/ruby-2.5.0/gems/apartment-2.1.0/lib/apartment/adapters/abstract_adapter.rb:85:in `switch'
.rvm/gems/ruby-2.5.0/gems/apartment-2.1.0/lib/apartment/migrator.rb:10:in `migrate'
.rvm/gems/ruby-2.5.0/gems/apartment-2.1.0/lib/tasks/apartment.rake:36:in `block (3 levels) in <top (required)>'
.rvm/gems/ruby-2.5.0/gems/apartment-2.1.0/lib/tasks/apartment.rake:124:in `block in each_tenant'
.rvm/gems/ruby-2.5.0/gems/parallel-1.12.1/lib/parallel.rb:486:in `call_with_index'
.rvm/gems/ruby-2.5.0/gems/parallel-1.12.1/lib/parallel.rb:318:in `block in work_direct'
.rvm/gems/ruby-2.5.0/gems/parallel-1.12.1/lib/parallel.rb:495:in `with_instrumentation'
.rvm/gems/ruby-2.5.0/gems/parallel-1.12.1/lib/parallel.rb:317:in `work_direct'
.rvm/gems/ruby-2.5.0/gems/parallel-1.12.1/lib/parallel.rb:260:in `map'
.rvm/gems/ruby-2.5.0/gems/parallel-1.12.1/lib/parallel.rb:217:in `each'
.rvm/gems/ruby-2.5.0/gems/apartment-2.1.0/lib/tasks/apartment.rake:123:in `each_tenant'
.rvm/gems/ruby-2.5.0/gems/apartment-2.1.0/lib/tasks/apartment.rake:33:in `block (2 levels) in <top (required)>'
.rvm/gems/ruby-2.5.0/gems/apartment-2.1.0/lib/apartment/tasks/enhancements.rb:44:in `block in enhance_after_task'
.rvm/gems/ruby-2.5.0@global/gems/rake-12.3.0/exe/rake:27:in `<top (required)>'
Tasks: TOP => apartment:migrate

```
5.1 vs 5.2 code:

https://github.com/rails/rails/blob/v5.1.5.rc1/activerecord/lib/active_record/migration.rb#L982
https://github.com/rails/rails/blob/v5.2.0.rc1/activerecord/lib/active_record/migration.rb#L1007


