### PR TITLE
Swallow the AR::NoDatabaseError without printing an error message

### DIFF
--- a/lib/apartment/railtie.rb
+++ b/lib/apartment/railtie.rb
@@ -27,11 +27,11 @@ module Apartment
     #   See the middleware/console declarations below to help with this. Hope to fix that soon.
     #
     config.to_prepare do
+      next if ARGV.any? { |arg| arg =~ /\Aassets:(?:precompile|clean)\z/ }
+
       begin
-        unless ARGV.any? { |arg| arg =~ /\Aassets:(?:precompile|clean)\z/ }
-          Apartment.connection_class.connection_pool.with_connection do
-            Apartment::Tenant.init
-          end
+        Apartment.connection_class.connection_pool.with_connection do
+          Apartment::Tenant.init
         end
       rescue ::ActiveRecord::NoDatabaseError => e
         puts e.message

--- a/lib/apartment/railtie.rb
+++ b/lib/apartment/railtie.rb
@@ -33,8 +33,9 @@ module Apartment
         Apartment.connection_class.connection_pool.with_connection do
           Apartment::Tenant.init
         end
-      rescue ::ActiveRecord::NoDatabaseError => e
-        puts e.message
+      rescue ::ActiveRecord::NoDatabaseError
+        # Since `db:create` and other tasks invoke this block from Rails 5.2.0,
+        # we need to swallow the error to execute `db:create` properly.
       end
     end
 


### PR DESCRIPTION
Printing an Error message is a little bit annoying until invoke `db:create`.

Related: #519 