### PR TITLE
Use docker containers for databases on Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
+sudo: required
 language: ruby
+services:
+  - docker
 rvm:
   - 2.1.9
   - 2.2.9
@@ -15,6 +18,9 @@ gemfile:
   - gemfiles/rails_master.gemfile
 bundler_args: --without local
 before_install:
+  - sudo /etc/init.d/mysql stop
+  - sudo /etc/init.d/postgresql stop
+  - docker-compose up -d
   - gem install bundler -v '> 1.5.0'
 env:
   RUBY_GC_MALLOC_LIMIT: 90000000

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,13 @@ language: ruby
 services:
   - docker
 rvm:
+  - jruby-9.1.15.0
   - 2.1.9
   - 2.2.9
   - 2.3.6
   - 2.4.3
   - 2.5.0
   - ruby-head
-  - jruby-9.1.15.0
 gemfile:
   - gemfiles/rails_4_2.gemfile
   - gemfiles/rails_5_0.gemfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '2.3'
 services:
   postgresql:
     image: postgres:9.5.12
@@ -6,9 +6,28 @@ services:
       POSTGRES_PASSWORD: ""
     ports:
       - "5432:5432"
+    healthcheck:
+      test: pg_isready -U postgres
+      start_period: 10s
+      interval: 10s
+      timeout: 30s
+      retries: 3
   mysql:
     image: mysql:5.7
     environment:
       MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
     ports:
       - "3306:3306"
+    healthcheck:
+      test: mysqladmin -h 127.0.0.1 -uroot ping
+      start_period: 15s
+      interval: 10s
+      timeout: 30s
+      retries: 3
+  healthcheck:
+    image: busybox
+    depends_on:
+      postgresql:
+        condition: service_healthy
+      mysql:
+        condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   postgresql:
-    image: postgres:10.3
+    image: postgres:9.5.12
     environment:
       POSTGRES_PASSWORD: ""
     ports:

--- a/spec/config/database.yml.sample
+++ b/spec/config/database.yml.sample
@@ -9,6 +9,8 @@ connections:
     url: jdbc:postgresql://localhost:5432/apartment_postgresql_test
     timeout: 5000
     pool: 5
+    host: localhost
+    port: 5432
 
   mysql:
     adapter: mysql
@@ -19,6 +21,8 @@ connections:
     url: jdbc:mysql://localhost:3306/apartment_mysql_test
     timeout: 5000
     pool: 5
+    host: 127.0.0.1
+    port: 3306
 <% else %>
 connections:
   postgresql:
@@ -28,12 +32,16 @@ connections:
     username: postgres
     schema_search_path: public
     password:
+    host: localhost
+    port: 5432
 
   mysql:
     adapter: mysql2
     database: apartment_mysql_test
     username: root
     password:
+    host: 127.0.0.1
+    port: 3306
 
   sqlite:
     adapter: sqlite3

--- a/spec/dummy/config/database.yml.sample
+++ b/spec/dummy/config/database.yml.sample
@@ -29,6 +29,8 @@ test:
   min_messages: WARNING
   pool: 5
   timeout: 5000
+  host: localhost
+  port: 5432
 
 development:
   adapter: postgresql
@@ -37,4 +39,6 @@ development:
   min_messages: WARNING
   pool: 5
   timeout: 5000
+  host: localhost
+  port: 5432
 <% end %>


### PR DESCRIPTION
It is convenient to specify version of database.

To solve problem like #532, we need this.