### PR TITLE
Dump schema after every tenant migration

### DIFF
--- a/spec/integration/apartment_rake_integration_spec.rb
+++ b/spec/integration/apartment_rake_integration_spec.rb
@@ -71,7 +71,11 @@ describe "apartment rake tasks", database: :postgresql do
     end
 
     context "with ActiveRecord above or equal to 5.2.0" do
-      let(:migration_context_double) { double(:migration_context) }
+      let(:migration_context_double) do
+        context = double(:migration_context)
+        allow(context).to receive(:current_version).and_return("20111202022214")
+        context
+      end
 
       before do
         allow(Apartment::Migrator).to receive(:activerecord_below_5_2?) { false }


### PR DESCRIPTION
With an existing tenant in our database, the `db/structure.sql` file is not updated with migrations for the tenant(s) the first time they're run. We're having to run the migrations a second time so that the `db/structure.sql` accurately reflects the changes to the database.

This change dumps the schema after every tenant, overwriting the existing file as usual, so that when all the migrations are complete, the schema will be completely up-to-date. The schema is dumped after each tenant rather than after all the migrations in case one of the tenants fails to migrate - the schema will at least continue to represent the current state of the database.