### PR TITLE
changes migrator.rb "activerecord_below_5_2" to support Rails < 4

### DIFF
--- a/lib/apartment/migrator.rb
+++ b/lib/apartment/migrator.rb
@@ -45,7 +45,11 @@ module Apartment
     private
 
     def activerecord_below_5_2?
-      ActiveRecord.version.release < Gem::Version.new('5.2.0')
+      if ActiveRecord.respond_to?(:version)
+        ActiveRecord.version.release < Gem::Version.new('5.2.0')
+      else
+        true
+      end
     end
   end
 end


### PR DESCRIPTION
ActiveRecord.version is only defined in Rails 4+.