### PR TITLE
Fix compatibility with Rails 3

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -116,7 +116,7 @@ def my_config
 end
 
 def activerecord_below_5_2?
-  ActiveRecord.version.release < Gem::Version.new('5.2.0')
+  ActiveRecord.respond_to?(:version) ? ActiveRecord.version.release < Gem::Version.new('5.2.0') : true
 end
 
 def migrate

--- a/lib/apartment/migrator.rb
+++ b/lib/apartment/migrator.rb
@@ -45,7 +45,7 @@ module Apartment
     private
 
     def activerecord_below_5_2?
-      ActiveRecord.version.release < Gem::Version.new('5.2.0')
+      ActiveRecord.respond_to?(:version) ? ActiveRecord.version.release < Gem::Version.new('5.2.0') : true
     end
   end
 end


### PR DESCRIPTION
Since `ActiveRecord.version` was added in Rails 4, it causes a `NoMethodError` in Rails 3 and under. This is a small fix to prevent that from happening and retain the method's logic value.