### PR TITLE
Update apartment.rake

### DIFF
--- a/lib/tasks/apartment.rake
+++ b/lib/tasks/apartment.rake
@@ -130,7 +130,7 @@ apartment_namespace = namespace :apartment do
   end
 
   def warn_if_tenants_empty
-    if tenants.empty?
+    if tenants.empty? && ENV['IGNORE_EMPTY_TENANTS'] != "true"
       puts <<-WARNING
         [WARNING] - The list of tenants to migrate appears to be empty. This could mean a few things:
 


### PR DESCRIPTION
Add environment check to quiet empty tenants warning.

We have a development set-up that does not utilize any tenants as expected, and would like the ability to prevent this message from filling the console during our tasks.