### PR TITLE
Support development in rails engines

### DIFF
--- a/lib/apartment/adapters/sqlite3_adapter.rb
+++ b/lib/apartment/adapters/sqlite3_adapter.rb
@@ -10,7 +10,7 @@ module Apartment
   module Adapters
     class Sqlite3Adapter < AbstractAdapter
       def initialize(config)
-        @default_dir = File.expand_path(File.dirname(config[:database]))
+        @default_dir = File.join(Rails.root, File.dirname(config[:database]))
 
         super
       end


### PR DESCRIPTION
This is about changing the value of @default_dir to support a {test,spec}/dummy path in an engine. Given an out of the box config/database.yml of:
```yaml
default: &default
  adapter: sqlite3
  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
  timeout: 5000

development:
  <<: *default
  database: db/development.sqlite3
```
Using the current `File.expand_path(config[:database])`, `@default_dir` will be set to a path of `application_root_dir/db` which is fine in a typical rails application. However when developing an engine, the database for the dummy app, e.g. `spec/dummy/config/database.yml` has the same config as above the result of which is that `@default_dir` is still set `application_root_dir/db` whereas the app expects to find sqlite3 files in `application_root_dir/{test,spec}/dummy/db`. Switching to `Rails.root` solves this issue and does not affect a 'standard' rails app