### PR TITLE
Move environmentify to a public class method

### DIFF
--- a/lib/apartment/adapters/abstract_adapter.rb
+++ b/lib/apartment/adapters/abstract_adapter.rb
@@ -120,6 +120,25 @@ module Apartment
       end
       alias_method :seed, :seed_data
 
+      #   Prepend the environment if configured and the environment isn't already there
+      #
+      #   @param {String} tenant Database name
+      #   @return {String} tenant name with Rails environment *optionally* prepended
+      #
+      def environmentify(tenant)
+        unless tenant.include?(Rails.env)
+          if Apartment.prepend_environment
+            "#{Rails.env}_#{tenant}"
+          elsif Apartment.append_environment
+            "#{tenant}_#{Rails.env}"
+          else
+            tenant
+          end
+        else
+          tenant
+        end
+      end
+
     protected
 
       def process_excluded_model(excluded_model)
@@ -161,25 +180,6 @@ module Apartment
       rescue *rescuable_exceptions => exception
         Apartment::Tenant.reset if reset_on_connection_exception?
         raise_connect_error!(tenant, exception)
-      end
-
-      #   Prepend the environment if configured and the environment isn't already there
-      #
-      #   @param {String} tenant Database name
-      #   @return {String} tenant name with Rails environment *optionally* prepended
-      #
-      def environmentify(tenant)
-        unless tenant.include?(Rails.env)
-          if Apartment.prepend_environment
-            "#{Rails.env}_#{tenant}"
-          elsif Apartment.append_environment
-            "#{tenant}_#{Rails.env}"
-          else
-            tenant
-          end
-        else
-          tenant
-        end
       end
 
       #   Import the database schema

--- a/lib/apartment/tenant.rb
+++ b/lib/apartment/tenant.rb
@@ -8,7 +8,7 @@ module Apartment
     extend self
     extend Forwardable
 
-    def_delegators :adapter, :create, :drop, :switch, :switch!, :current, :each, :reset, :set_callback, :seed, :current_tenant, :default_tenant
+    def_delegators :adapter, :create, :drop, :switch, :switch!, :current, :each, :reset, :set_callback, :seed, :current_tenant, :default_tenant, :environmentify
 
     attr_writer :config
 


### PR DESCRIPTION
We've found this method to be useful in a multi-db environment. This PR simply exposes this method to be used in application code.