### PR TITLE
Don't initialize tenant when running rails webpacker:compile

### DIFF
--- a/lib/apartment/railtie.rb
+++ b/lib/apartment/railtie.rb
@@ -28,7 +28,7 @@ module Apartment
     #
     config.to_prepare do
       next if ARGV.any? { |arg| arg =~ /\Aassets:(?:precompile|clean)\z/ }
-      next if ARGV.any? { |arg| arg == 'webpacker:compile'}
+      next if ARGV.any? { |arg| arg == 'webpacker:compile' }
 
       begin
         Apartment.connection_class.connection_pool.with_connection do

--- a/lib/apartment/railtie.rb
+++ b/lib/apartment/railtie.rb
@@ -28,7 +28,7 @@ module Apartment
     #
     config.to_prepare do
       next if ARGV.any? { |arg| arg =~ /\Aassets:(?:precompile|clean)\z/ }
-      next if ARGV.any? { |arg| arg =~ /\Awebpacker:(?:compile)\z/ }
+      next if ARGV.any? { |arg| arg == 'webpacker:compile'}
 
       begin
         Apartment.connection_class.connection_pool.with_connection do

--- a/lib/apartment/railtie.rb
+++ b/lib/apartment/railtie.rb
@@ -28,6 +28,7 @@ module Apartment
     #
     config.to_prepare do
       next if ARGV.any? { |arg| arg =~ /\Aassets:(?:precompile|clean)\z/ }
+      next if ARGV.any? { |arg| arg =~ /\Awebpacker:(?:compile)\z/ }
 
       begin
         Apartment.connection_class.connection_pool.with_connection do


### PR DESCRIPTION
This skips the `config.to_prepare` block when running `bin/rails wepacker:compile`. 