### PR TITLE
Added mysql2_json_adapter support

### DIFF
--- a/lib/apartment/adapters/mysql2_json_adapter.rb
+++ b/lib/apartment/adapters/mysql2_json_adapter.rb
@@ -1,0 +1,17 @@
+require 'apartment/adapters/mysql2_adapter'
+
+module Apartment
+  module Tenant
+    
+    def self.mysql2_json_adapter(config)
+      Apartment.use_schemas ?
+        Adapters::Mysql2SchemaAdapter.new(config) :
+        Adapters::Mysql2Adapter.new(config)
+    end
+  end
+
+  module Adapters
+    class Mysql2JsonAdapter < Mysql2Adapter
+    end
+  end
+end

--- a/spec/adapters/mysql2json_adapter_spec.rb
+++ b/spec/adapters/mysql2json_adapter_spec.rb
@@ -1,0 +1,59 @@
+require 'spec_helper'
+require 'apartment/adapters/mysql2_json_adapter'
+
+describe Apartment::Adapters::Mysql2JsonAdapter, database: :mysql do
+  unless defined?(JRUBY_VERSION)
+
+    subject(:adapter){ Apartment::Tenant.mysql2json_adapter config }
+
+    def tenant_names
+      ActiveRecord::Base.connection.execute("SELECT schema_name FROM information_schema.schemata").collect { |row| row[0] }
+    end
+
+    let(:default_tenant) { subject.switch { ActiveRecord::Base.connection.current_database } }
+
+    context "using - the equivalent of - schemas" do
+      before { Apartment.use_schemas = true }
+
+      it_should_behave_like "a generic apartment adapter"
+
+      describe "#default_tenant" do
+        it "is set to the original db from config" do
+          expect(subject.default_tenant).to eq(config[:database])
+        end
+      end
+
+      describe "#init" do
+        include Apartment::Spec::AdapterRequirements
+
+        before do
+          Apartment.configure do |config|
+            config.excluded_models = ["Company"]
+          end
+        end
+
+        after do
+          # Apartment::Tenant.init creates per model connection.
+          # Remove the connection after testing not to unintentionally keep the connection across tests.
+          Apartment.excluded_models.each do |excluded_model|
+            excluded_model.constantize.remove_connection
+          end
+        end
+
+        it "should process model exclusions" do
+          Apartment::Tenant.init
+
+          expect(Company.table_name).to eq("#{default_tenant}.companies")
+        end
+      end
+    end
+
+    context "using connections" do
+      before { Apartment.use_schemas = false }
+
+      it_should_behave_like "a generic apartment adapter"
+      it_should_behave_like "a generic apartment adapter able to handle custom configuration"
+      it_should_behave_like "a connection based apartment adapter"
+    end
+  end
+end


### PR DESCRIPTION
Adds support to **mysql2_json** adapter (https://github.com/saveriomiroddi/json_on_rails).

Recently we have updated our application from **Rails 4.1** to **Rails 4.2**. This created an  incompatibility with our json tables on MySQL 5.7. We had to switch from **mysql2** to **mysql2_json** adapter to fix that while we don't update to Rails 5. Basically this gem adds json features on Rails 4.2.