### PR TITLE
chore: Support rails 6.1.1

### DIFF
--- a/apartment.gemspec
+++ b/apartment.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.licenses = ["MIT"]
 
   # must be >= 3.1.2 due to bug in prepared_statements
-  s.add_dependency 'activerecord',    '>= 3.1.2', '< 6.1'
+  s.add_dependency 'activerecord',    '>= 3.1.2'
   s.add_dependency 'rack',            '>= 1.3.6'
   s.add_dependency 'public_suffix',   '>= 2'
   s.add_dependency 'parallel',        '>= 0.7.1'


### PR DESCRIPTION
Supports the latest Rails 6.1.

Without this, when I just install the gem with Rails 6.1.1, the version installed was 0.24.3.