### PR TITLE
Support Rails 6.1

### DIFF
--- a/apartment.gemspec
+++ b/apartment.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.licenses = ["MIT"]
 
   # must be >= 3.1.2 due to bug in prepared_statements
-  s.add_dependency 'activerecord',    '>= 3.1.2', '< 6.1'
+  s.add_dependency 'activerecord',    '>= 3.1.2', '< 6.2'
   s.add_dependency 'rack',            '>= 1.3.6'
   s.add_dependency 'public_suffix',   '>= 2'
   s.add_dependency 'parallel',        '>= 0.7.1'

--- a/apartment.gemspec
+++ b/apartment.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.licenses = ["MIT"]
 
   # must be >= 3.1.2 due to bug in prepared_statements
-  s.add_dependency 'activerecord',    '>= 3.1.2', '< 6.2'
+  s.add_dependency 'activerecord',    '>= 3.1.2', '< 8.0'
   s.add_dependency 'rack',            '>= 1.3.6'
   s.add_dependency 'public_suffix',   '>= 2'
   s.add_dependency 'parallel',        '>= 0.7.1'

--- a/lib/apartment.rb
+++ b/lib/apartment.rb
@@ -16,7 +16,15 @@ module Apartment
     attr_accessor(*ACCESSOR_METHODS)
     attr_writer(*WRITER_METHODS)
 
-    def_delegators :connection_class, :connection, :connection_config, :establish_connection
+    def_delegators :connection_class, :connection, :establish_connection
+
+    def connection_config
+      if ::ActiveRecord::Base.respond_to?(:connection_db_config)
+        ::ActiveRecord::Base.connection_db_config.configuration_hash
+      else
+        ::ActiveRecord::Base.connection_config
+      end
+    end
 
     # configure apartment with available options
     def configure


### PR DESCRIPTION
Rails 6 is not going to replace Apartment for us. It seems to be geared toward switching between known (at boot time) databases, whereas we need support for new databases at runtime. 